### PR TITLE
.ruby-gemset to use specific gemset

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+cancancan


### PR DESCRIPTION
`Cancancan` uses `.ruby-version` to set ruby automatically. This pull request adds `.ruby-gemset`, which sets gemset automatically. This allows to isolate project specific gems from gems of other projects and also allows to not use `bundle exec`.
