### PR TITLE
Add docs badge to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,6 +2,7 @@
 {<img src="https://badge.fury.io/rb/cancancan.png" alt="Gem Version" />}[http://badge.fury.io/rb/cancancan]
 {<img src="https://travis-ci.org/CanCanCommunity/cancancan.png?branch=master" alt="Build Status" />}[https://travis-ci.org/CanCanCommunity/cancancan]
 {<img src="https://codeclimate.com/github/bryanrite/cancancan.png?" alt="Code Climate" />}[https://codeclimate.com/github/bryanrite/cancancan]
+{<img src="http://inch-pages.github.io/github/CanCanCommunity/cancancan.png" alt="Inline docs" />}[http://inch-pages.github.io/github/CanCanCommunity/cancancan]
 
 Wiki[https://github.com/bryanrite/cancancan/wiki] | RDocs[http://rdoc.info/projects/ryanb/cancan] | Screencast[http://railscasts.com/episodes/192-authorization-with-cancan]
 


### PR DESCRIPTION
Hi Bryan,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/CanCanCommunity/cancancan.png)](http://inch-pages.github.io/github/CanCanCommunity/cancancan)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for CanCanCan is http://inch-pages.github.io/github/CanCanCommunity/cancancan/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
