### PR TITLE
Updated matchers to work with rspec 3.0.0

### DIFF
--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -4,11 +4,13 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
     ability.can?(*args)
   end
 
-  failure_message_for_should do |ability|
+  failure_message do |ability|
     "expected to be able to #{args.map(&:inspect).join(" ")}"
   end
+  alias failure_message_for_should failure_message
 
-  failure_message_for_should_not do |ability|
+  failure_message_when_negated do |ability|
     "expected not to be able to #{args.map(&:inspect).join(" ")}"
   end
+  alias failure_message_for_should_not failure_message_when_negated
 end

--- a/spec/matchers.rb
+++ b/spec/matchers.rb
@@ -3,13 +3,11 @@ RSpec::Matchers.define :orderlessly_match do |original_string|
     original_string.split('').sort == given_string.split('').sort
   end
 
-  failure_message do |given_string|
+  failure_message_for_should do |given_string|
     "expected \"#{given_string}\" to have the same characters as \"#{original_string}\""
   end
-  alias failure_message_for_should failure_message
 
-  failure_message_when_negated do |given_string|
+  failure_message_for_should_not do |given_string|
     "expected \"#{given_string}\" not to have the same characters as \"#{original_string}\""
   end
-  alias failure_message_for_should_not failure_message_when_negated
 end


### PR DESCRIPTION
When writing tests for abilities, using rspec 3.0.0 I got this message:

failure_message_for_should_not is deprecated. Use failure_message_when_negated instead. Called from /home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/cancancan-1.7.0/lib/cancan/matchers.rb:11

failure_message_for_should is deprecated. Use failure_message instead. Called from /home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/cancancan-1.7.0/lib/cancan/matchers.rb:7
