### PR TITLE
add support for array of matchers

### DIFF
--- a/lib/cancan.rb
+++ b/lib/cancan.rb
@@ -1,4 +1,4 @@
-require "cancan/version"
+require 'cancan/version'
 require 'cancan/ability'
 require 'cancan/rule'
 require 'cancan/controller_resource'
@@ -6,7 +6,6 @@ require 'cancan/controller_additions'
 require 'cancan/model_additions'
 require 'cancan/exceptions'
 require 'cancan/inherited_resource'
-require 'cancan/matchers'
 
 require 'cancan/model_adapters/abstract_adapter'
 require 'cancan/model_adapters/default_adapter'

--- a/lib/cancancan/matchers.rb
+++ b/lib/cancancan/matchers.rb
@@ -1,10 +1,9 @@
-rspec_module = defined?(RSpec::Core) ? 'RSpec' : 'Spec'  # for RSpec 1 compatability
-Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
+RSpec::Matchers.define :be_able_to do |*args|
   match do |ability|
     if args[0].is_a? Array
       args[0].all? do |action|
         ability.can?(action, args[1])
-      endx
+      end
     else
       ability.can?(*args)
     end


### PR DESCRIPTION
It seems natural to include an input of an array into the spec matcher if you can also define it as such within the Ability model. Also, sets up matches under cancancan directory for require 'cancancan/matchers'.
