### PR TITLE
Fixed namespace method to be able to use controller inside modules

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -248,7 +248,7 @@ module CanCan
     end
 
     def namespace
-      @params[:controller].split(/::|\//)[0..-2]
+      @params[:controller].split(/::|\//)[0..-2].map(&:camelize)
     end
 
     def namespaced_name


### PR DESCRIPTION
CanCanCan didn't work for me when I had controllers in paths like this:
`app/models/controllers/pages/qa/questions_controller.rb`

I think this change fixes this. Btw, I don't understand why there is no `camelize` call in `namespace` or in `namespaced_name`
