### PR TITLE
Support detection of community vs canonical version.

### DIFF
--- a/lib/cancancan.rb
+++ b/lib/cancancan.rb
@@ -1,6 +1,4 @@
 require 'cancan'
 
-# Allows for assemblies that work with either community or canononical CanCan to detect
-# which version is actually in use.
 module CanCanCan
 end


### PR DESCRIPTION
I've got a few internal gems used across multiple projects that depend on some of the broken behavior of the canonical version of CanCan. I'm upgrading as I can but I need to support some way of detecting which is currently in use by the host project.

This simple change just adds a CanCanCan module that can be checked for existence so we can do things like

``` ruby
unless defined?(CanCanCan)
  do_some_codefu_to_fix_cancan_strong_parameters
end
```
