### PR TITLE
Don't call helper_method if it does not exist

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -294,7 +294,7 @@ module CanCan
 
     def self.included(base)
       base.extend ClassMethods
-      base.helper_method :can?, :cannot?, :current_ability
+      base.helper_method :can?, :cannot?, :current_ability if base.respond_to? :helper_method
     end
 
     # Raises a CanCan::AccessDenied exception if the current_ability cannot


### PR DESCRIPTION
Allows us to use cancancan inside of Grape without monkey patching it.
