### PR TITLE
Allow Rule to carry around a hash of options.

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -126,8 +126,8 @@ module CanCan
     #     # check the database and return true/false
     #   end
     #
-    def can(action = nil, subject = nil, conditions = nil, &block)
-      rules << Rule.new(true, action, subject, conditions, block)
+    def can(action = nil, subject = nil, conditions = nil, options = nil, &block)
+      rules << Rule.new(true, action, subject, conditions, options, block)
     end
 
     # Defines an ability which cannot be done. Accepts the same arguments as "can".
@@ -142,8 +142,8 @@ module CanCan
     #     product.invisible?
     #   end
     #
-    def cannot(action = nil, subject = nil, conditions = nil, &block)
-      rules << Rule.new(false, action, subject, conditions, block)
+    def cannot(action = nil, subject = nil, conditions = nil, options = nil, &block)
+      rules << Rule.new(false, action, subject, conditions, options, block)
     end
 
     # Alias one or more actions into another one.
@@ -208,8 +208,11 @@ module CanCan
       if args.last.kind_of?(Hash) && args.last.has_key?(:message)
         message = args.pop[:message]
       end
-      if cannot?(action, subject, *args)
-        message ||= unauthorized_message(action, subject)
+      message ||= unauthorized_message(action, subject)
+      match = match(action, subject, *args)
+      if match
+        raise AccessDenied.new(message, action, subject, match) unless match.base_behavior
+      else
         raise AccessDenied.new(message, action, subject)
       end
       subject

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -61,16 +61,10 @@ module CanCan
     #
     # Also see the RSpec Matchers to aid in testing.
     def can?(action, subject, *extra_args)
-      subject = extract_subjects(subject)
-
-      match = subject.map do |subject|
-        relevant_rules_for_match(action, subject).detect do |rule|
-          rule.matches_conditions?(action, subject, extra_args)
-        end
-      end.compact.first
-
+      match = match(action, subject, *extra_args)
       match ? match.base_behavior : false
     end
+
     # Convenience method which works the same as "can?" but returns the opposite value.
     #
     #   cannot? :destroy, @project
@@ -331,6 +325,16 @@ module CanCan
           raise Error, "The accessible_by call cannot be used with a block 'can' definition. The SQL cannot be determined for #{action.inspect} #{subject.inspect}"
         end
       end
+    end
+
+    def match(action, subject, *extra_args)
+      subject = extract_subjects(subject)
+
+      subject.map do |subject|
+        relevant_rules_for_match(action, subject).detect do |rule|
+          rule.matches_conditions?(action, subject, extra_args)
+        end
+      end.compact.first
     end
 
     def default_alias_actions

--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -33,13 +33,14 @@ module CanCan
   # See ControllerAdditions#authorized! for more information on rescuing from this exception
   # and customizing the message using I18n.
   class AccessDenied < Error
-    attr_reader :action, :subject
+    attr_reader :action, :subject, :match
     attr_writer :default_message
 
-    def initialize(message = nil, action = nil, subject = nil)
+    def initialize(message = nil, action = nil, subject = nil, match = nil)
       @message = message
       @action = action
       @subject = subject
+      @match = match
       @default_message = I18n.t(:"unauthorized.default", :default => "You are not authorized to access this page.")
     end
 

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -3,20 +3,21 @@ module CanCan
   # it holds the information about a "can" call made on Ability and provides
   # helpful methods to determine permission checking and conditions hash generation.
   class Rule # :nodoc:
-    attr_reader :base_behavior, :subjects, :actions, :conditions
+    attr_reader :base_behavior, :subjects, :actions, :conditions, :options
     attr_writer :expanded_actions
 
     # The first argument when initializing is the base_behavior which is a true/false
     # value. True for "can" and false for "cannot". The next two arguments are the action
     # and subject respectively (such as :read, @project). The third argument is a hash
     # of conditions and the last one is the block passed to the "can" call.
-    def initialize(base_behavior, action, subject, conditions, block)
+    def initialize(base_behavior, action, subject, conditions, options, block)
       raise Error, "You are not able to supply a block with a hash of conditions in #{action} #{subject} ability. Use either one." if conditions.kind_of?(Hash) && !block.nil?
       @match_all = action.nil? && subject.nil?
       @base_behavior = base_behavior
       @actions = [action].flatten
       @subjects = [subject].flatten
       @conditions = conditions || {}
+      @options = options
       @block = block
     end
 

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -415,6 +415,17 @@ describe CanCan::Ability do
     end
   end
 
+  it "passes the match to CanCan::AccessDenied" do
+    @ability.cannot :read, :foo, nil, error: "Sorry, can't do that."
+    begin
+      @ability.authorize! :read, :foo
+    rescue CanCan::AccessDenied => e
+      expect(e.match.options).to eq(error: "Sorry, can't do that.")
+    else
+      fail "Expected CanCan::AccessDenied exception to be raised"
+    end
+  end
+
   it "determines model adapterO class by asking AbstractAdapter" do
     adapter_class, model_class = double, double
     allow(CanCan::ModelAdapters::AbstractAdapter).to receive(:adapter_class).with(model_class) { adapter_class }

--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -5,7 +5,7 @@ require "ostruct" # for OpenStruct below
 describe CanCan::Rule do
   before(:each) do
     @conditions = {}
-    @rule = CanCan::Rule.new(true, :read, Integer, @conditions, nil)
+    @rule = CanCan::Rule.new(true, :read, Integer, @conditions, nil, nil)
   end
 
   it "returns no association joins if none exist" do
@@ -34,7 +34,7 @@ describe CanCan::Rule do
   end
 
   it "returns no association joins if conditions is nil" do
-    rule = CanCan::Rule.new(true, :read, Integer, nil, nil)
+    rule = CanCan::Rule.new(true, :read, Integer, nil, nil, nil)
     expect(rule.associations_hash).to eq({})
   end
 


### PR DESCRIPTION
This does 3 things.

* Extracts a private `match` method for more reusability.
* Allows a `CanCan::Rule` to carry a hash of options around.
* When a match is found but it doesn't allow access, that match is also provided to CanCan::AccessDenied.

The idea behind this would be to allow an api to respond with a reason for why the request is denied, so this allows you to define a rule like:

```ruby
cannot :join, Thing, nil, reason: :more_info
```