### PR TITLE
Do not end initialization process before assign attributes

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -77,8 +77,9 @@ module CanCan
     end
 
     def build_resource
-      resource = resource_base.new(resource_params || {})
-      assign_attributes(resource)
+      resource_base.new(resource_params || {}) do |resource|
+        assign_attributes(resource)
+      end
     end
 
     def assign_attributes(resource)

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -14,6 +14,7 @@ describe CanCan::ControllerResource do
         attributes.each do |attribute, value|
           send("#{attribute}=", value)
         end
+        yield self if block_given?
       end
     end
 


### PR DESCRIPTION
Make sure that `after_initialize` callback for resource will be called
after assigning attributes from abilities. This is possible because
most of AR methods are able to take optional block argument.