### PR TITLE
Proposed fix for an issue where CanCanCan breaks when the model is named "Action"

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,8 @@
 Develop
 
+1.9.3 (November 25th, 2014)
+
+* Fix cancancan#125 - Fix an issue where model is named Action. (yoongkang)
 
 1.9.2 (August 8th, 2014)
 

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -240,6 +240,8 @@ module CanCan
         @params[extract_key(@options[:instance_name])]
       elsif @options[:class] && @params.has_key?(extract_key(@options[:class]))
         @params[extract_key(@options[:class])]
+      elsif name == "action"
+        nil
       else
         @params[extract_key(namespaced_name)]
       end

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -634,4 +634,33 @@ describe CanCan::ControllerResource do
     expect { resource.load_and_authorize_resource }.not_to raise_error
     expect(controller.instance_variable_get(:@model)).to be_nil
   end
+
+  context "when model name is Action" do
+    let(:action_params) { HashWithIndifferentAccess.new(:controller => "actions") }
+    let(:action_controller_class) { Class.new }
+    let(:action_controller) { controller_class.new }
+    before :each do
+      class Action
+        attr_accessor :name
+
+        def initialize(attributes={})
+          attributes.each do |attribute, value|
+            send("#{attribute}=", value)
+          end
+        end
+      end
+
+    allow(action_controller).to receive(:params) { action_params }
+    allow(action_controller).to receive(:current_ability) { ability }
+    allow(action_controller_class).to receive(:cancan_skipper) { {:authorize => {}, :load => {}} }
+    end
+
+    it "builds a new resource with attributes from current ability" do
+      action_params.merge!(:action => 'create')
+      ability.can(:create, Action, :name => "from conditions")
+      resource = CanCan::ControllerResource.new(action_controller)
+      resource.load_resource
+      expect(action_controller.instance_variable_get(:@action).name).to eq("from conditions")
+    end
+  end
 end


### PR DESCRIPTION
Newbie Ruby dev here! *waves*

I -think- this fixes issue #125, at least partially.

The problem occurs in resource_params_by_namespaced_name. There is a bug due to the key in the hash being the same as the model name, returning a value when it's not supposed to.

Would appreciate any review (relatively new to Ruby, as mentioned). Thanks.