### PR TITLE
Resource Namespace Load fix

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -263,7 +263,7 @@ module CanCan
     end
 
     def namespaced_name
-      [namespace, name.camelize].join('::').singularize.camelize.constantize
+      [namespace, name.camelize].flatten.map(&:camelize).join('::').singularize.constantize
     rescue NameError
       name
     end

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -103,6 +103,17 @@ describe CanCan::ControllerResource do
       expect(controller.instance_variable_get(:@sub_model).name).to eq("foobar")
     end
 
+    it "builds a new resource for namespaced controller given through folder format" do
+      module Admin
+        module SubModule
+          class HiddenModel < ::Model; end
+        end
+      end
+      params.merge!(:controller => "admin/sub_module/hidden_models")
+      resource = CanCan::ControllerResource.new(controller)
+      expect { resource.load_resource }.not_to raise_error
+    end
+
     it "does not build record through has_one association with :singleton option because it can cause it to delete it in the database" do
       category = Class.new
       allow_any_instance_of(Model).to receive('category=').with(category)


### PR DESCRIPTION
This PR solves a bug where, when a model is under 2 or more modules, it fails to be loaded

fixes https://github.com/CanCanCommunity/cancancan/issues/146