### PR TITLE
Shorten output for custom matcher

### DIFF
--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -28,6 +28,6 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
   end
 
   description do
-    "should be able to #{args.map(&:to_s).join(' ')}"
+    "expected to be able to #{args.map(&:to_s).join(' ')}"
   end
 end

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -38,6 +38,6 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
   end
 
   description do
-    "expected to be able to #{args.map(&:to_s).join(' ')}"
+    "be able to #{args.map(&:to_s).join(' ')}"
   end
 end

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -1,10 +1,11 @@
-rspec_module = defined?(RSpec::Core) ? 'RSpec' : 'Spec'  # for RSpec 1 compatability
+rspec_module = defined?(RSpec::Core) ? 'RSpec' : 'Spec' # RSpec 1 compatability
 
 if rspec_module == 'RSpec'
   require 'rspec/core'
   require 'rspec/expectations'
 else
-  ActiveSupport::Deprecation.warn("RSpec < 3 will not be supported in the CanCanCan >= 2.0.0")
+  ActiveSupport::Deprecation
+    .warn('RSpec < 3 will not be supported in the CanCanCan >= 2.0.0')
 end
 
 Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
@@ -18,11 +19,15 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
     alias :failure_message_when_negated :failure_message_for_should_not
   end
 
-  failure_message do |ability|
-    "expected to be able to #{args.map(&:inspect).join(" ")}"
+  failure_message do
+    "expected to be able to #{args.map(&:to_s).join(' ')}"
   end
 
-  failure_message_when_negated do |ability|
-    "expected not to be able to #{args.map(&:inspect).join(" ")}"
+  failure_message_when_negated do
+    "expected not to be able to #{args.map(&:to_s).join(' ')}"
+  end
+
+  description do
+    "should be able to #{args.map(&:to_s).join(' ')}"
   end
 end

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -20,14 +20,29 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
   end
 
   failure_message do
-    "expected to be able to #{args.map(&:to_s).join(' ')}"
+    resource = args[1]
+    if resource.instance_of?(Class)
+      "expected to be able to #{args.map(&:to_s).join(' ')}"
+    else
+      "expected to be able to #{args.map(&:inspect).join(' ')}"
+    end
   end
 
   failure_message_when_negated do
-    "expected not to be able to #{args.map(&:to_s).join(' ')}"
+    resource = args[1]
+    if resource.instance_of?(Class)
+      "expected not to be able to #{args.map(&:to_s).join(' ')}"
+    else
+      "expected not to be able to #{args.map(&:inspect).join(' ')}"
+    end
   end
 
   description do
-    "expected to be able to #{args.map(&:to_s).join(' ')}"
+    resource = args[1]
+    if resource.instance_of?(Class)
+      "expected to be able to #{args.map(&:to_s).join(' ')}"
+    else
+      "expected to be able to #{args.map(&:inspect).join(' ')}"
+    end
   end
 end

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -38,11 +38,6 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
   end
 
   description do
-    resource = args[1]
-    if resource.instance_of?(Class)
-      "expected to be able to #{args.map(&:to_s).join(' ')}"
-    else
-      "expected to be able to #{args.map(&:inspect).join(' ')}"
-    end
+    "expected to be able to #{args.map(&:to_s).join(' ')}"
   end
 end


### PR DESCRIPTION
Don't show the full object.inspect, just the name of the object. This was particularly noisy with documentation output.

Old output

![image](https://cloud.githubusercontent.com/assets/4521/5428636/2bb952be-8391-11e4-99cd-1e90e90616fa.png)

New output

![image](https://cloud.githubusercontent.com/assets/4521/5428638/3d04adac-8391-11e4-9e0f-d8fdd7f3cdad.png)

Failure old Constant

![image](https://cloud.githubusercontent.com/assets/4521/5428649/926f1854-8391-11e4-8106-91e9ebb99dbf.png)

Failure new Constant

![image](https://cloud.githubusercontent.com/assets/4521/5428646/7135e8fc-8391-11e4-9aba-ca3da15b5155.png)

Failure old instance

![image](https://cloud.githubusercontent.com/assets/4521/5428657/f91604e6-8391-11e4-8b90-49d44bb75bd8.png)

Failure new instance

![image](https://cloud.githubusercontent.com/assets/4521/5428660/08522a2a-8392-11e4-8bae-414a2fb40660.png)