### PR TITLE
Allow disabling ActiveRecord eager loading

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,7 @@
 Develop
 
+* Fix cancancan#60 - Allow disabling eager loading via ActiveRecord#includes
+
 
 1.10.1 (January 13th, 2015)
 

--- a/lib/cancan/model_adapters/abstract_adapter.rb
+++ b/lib/cancan/model_adapters/abstract_adapter.rb
@@ -47,7 +47,7 @@ module CanCan
         @rules = rules
       end
 
-      def database_records
+      def database_records(eager_load)
         # This should be overridden in a subclass to return records which match @rules
         raise NotImplemented, "This model adapter does not support fetching records from the database."
       end

--- a/lib/cancan/model_adapters/active_record_3_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_3_adapter.rb
@@ -39,8 +39,12 @@ module CanCan
 
       private
 
-      def build_relation(*where_conditions)
-        @model_class.where(*where_conditions).includes(joins)
+      def build_relation(eager_load = true, *where_conditions)
+        if eager_load
+          @model_class.where(*where_conditions).includes(joins)
+        else
+          @model_class.where(*where_conditions).joins(joins)
+        end
       end
     end
   end

--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -12,9 +12,15 @@ module CanCan
       # look inside the where clause to decide to outer join tables
       # you're using in the where. Instead, `references()` is required
       # in addition to `includes()` to force the outer join.
-      def build_relation(*where_conditions)
+      def build_relation(eager_load = true, *where_conditions)
         relation = @model_class.where(*where_conditions)
-        relation = relation.includes(joins).references(joins) if joins.present?
+        if joins.present?
+          if eager_load
+            relation = relation.includes(joins).references(joins)
+          else
+            relation = relation.joins(joins)
+          end
+        end
         relation
       end
 

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -60,14 +60,14 @@ module CanCan
         clean_joins(joins_hash) unless joins_hash.empty?
       end
 
-      def database_records
+      def database_records(eager_load = true)
         if override_scope
           @model_class.where(nil).merge(override_scope)
         elsif @model_class.respond_to?(:where) && @model_class.respond_to?(:joins)
           if mergeable_conditions?
-            build_relation(conditions)
+            build_relation(eager_load, conditions)
           else
-            build_relation(*(@rules.map(&:conditions)))
+            build_relation(eager_load, *(@rules.map(&:conditions)))
           end
         else
           @model_class.all(:conditions => conditions, :joins => joins)

--- a/lib/cancan/model_adapters/data_mapper_adapter.rb
+++ b/lib/cancan/model_adapters/data_mapper_adapter.rb
@@ -18,7 +18,7 @@ module CanCan
         !!collection.first(conditions)
       end
 
-      def database_records
+      def database_records(eager_load = true)
         scope = @model_class.all(:conditions => ["0 = 1"])
         cans, cannots = @rules.partition { |r| r.base_behavior }
         return scope if cans.empty?

--- a/lib/cancan/model_adapters/mongoid_adapter.rb
+++ b/lib/cancan/model_adapters/mongoid_adapter.rb
@@ -22,7 +22,7 @@ module CanCan
         subject.matches?( subject.class.where(conditions).selector )
       end
 
-      def database_records
+      def database_records(eager_load = true)
         if @rules.size == 0
           @model_class.where(:_id => {'$exists' => false, '$type' => 7}) # return no records in Mongoid
         elsif @rules.size == 1 && @rules[0].conditions.is_a?(Mongoid::Criteria)

--- a/lib/cancan/model_adapters/sequel_adapter.rb
+++ b/lib/cancan/model_adapters/sequel_adapter.rb
@@ -28,7 +28,7 @@ module CanCan
         end
       end
 
-      def database_records
+      def database_records(eager_load = true)
         if @rules.size == 0
           @model_class.where('1=0')
         else

--- a/lib/cancan/model_additions.rb
+++ b/lib/cancan/model_additions.rb
@@ -19,8 +19,14 @@ module CanCan
       #   @articles = Article.accessible_by(current_ability, :update)
       #
       # Here only the articles which the user can update are returned.
-      def accessible_by(ability, action = :index)
-        ability.model_adapter(self, action).database_records
+      #
+      # To prevent N+1 query problems, relations included in conditions are
+      # included in the query by default. eager_load allows disabling eager
+      # loading when needed. When eager_load is specified, only the model
+      # attributes will be loaded. Currently, this only has an effect for
+      # ActiveRecord.
+      def accessible_by(ability, action = :index, eager_load = true)
+        ability.model_adapter(self, action).database_records(eager_load)
       end
     end
 

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -179,6 +179,27 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
       expect(Comment.accessible_by(@ability)).to eq([comment1])
     end
 
+    it "continues to load comments with eager loading disabled" do
+      @ability.can :read, Comment, :article => { :category => { :visible => true } }
+      comment1 = Comment.create!(:article => Article.create!(:category => Category.create!(:visible => true)))
+      comment2 = Comment.create!(:article => Article.create!(:category => Category.create!(:visible => false)))
+      expect(Comment.accessible_by(@ability, :index, false)).to eq([comment1])
+    end
+
+    it "eager loads associated records by default" do
+      @ability.can :read, Comment, :article => { :category => { :visible => true } }
+      comment1 = Comment.create!(:article => Article.create!(:category => Category.create!(:visible => true)))
+      # loaded? and other methods I could find didn't return the correct values. Not sure why. This way works.
+      expect(Comment.accessible_by(@ability).first.instance_variable_get("@article")).not_to be_nil
+    end
+
+    it "allows disabling eager loading" do
+      @ability.can :read, Comment, :article => { :category => { :visible => true } }
+      comment1 = Comment.create!(:article => Article.create!(:category => Category.create!(:visible => true)))
+      # loaded? and other methods I could find didn't return the correct values. Not sure why. This way works.
+      expect(Comment.accessible_by(@ability, :index, false).first.instance_variable_get("@article")).to be_nil
+    end
+
     it "allows conditions in SQL and merge with hash conditions" do
       @ability.can :read, Article, :published => true
       @ability.can :read, Article, ["secret=?", true]


### PR DESCRIPTION
While #includes is useful to help avoid N+1 query problems, it can
cause challenges in other ways. In particular, complex queries that
involve large objects at the root of their chain can end up including
that large object for every row of the selected model.

As an example, imagine a blog post with many comments, each with an
author. We'd like to restrict access to the authors that have comments
on blog posts visible to the user. Your permission might look like:

```
can :read, User, {
  comment: { blog: { accessible_blogs: { user_id: @current_user.id } } }
}
```

Then you can do User.accessible_by(current_ability). That query will
give you a list of all the authors, but will also include the text of
the blog and comment. That becomes an issue for large blog posts with
many comments.

Using joins instead of includes, in this case, runs a query that only
selects User attributes.

Issue https://github.com/CanCanCommunity/cancancan/issues/60 has some more information on an application of this
fix.

---

Here's my first stab at allowing a toggle of includes/joins.

It sucks to have eager_load be passed to _all_ model_adapters, even if they
don't support this, but I can't think of a nicer way to do this. The argument
location seems poor, as well - is there a good alternative to passing it before
`where_conditions`?
