### PR TITLE
Significantly improve rule lookup time

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -133,7 +133,7 @@ module CanCan
     #   end
     #
     def can(action = nil, subject = nil, conditions = nil, &block)
-      rules << Rule.new(true, action, subject, conditions, block)
+      add_rule(Rule.new(true, action, subject, conditions, block))
     end
 
     # Defines an ability which cannot be done. Accepts the same arguments as "can".
@@ -149,7 +149,7 @@ module CanCan
     #   end
     #
     def cannot(action = nil, subject = nil, conditions = nil, &block)
-      rules << Rule.new(false, action, subject, conditions, block)
+      add_rule(Rule.new(false, action, subject, conditions, block))
     end
 
     # Alias one or more actions into another one.
@@ -247,7 +247,7 @@ module CanCan
 
     def merge(ability)
       ability.rules.each do |rule|
-        rules << rule.dup
+        add_rule(rule.dup)
       end
       self
     end
@@ -255,7 +255,7 @@ module CanCan
     protected
 
     def rules
-      @rules ||= []
+      @rules.values.flatten
     end
 
     private
@@ -308,15 +308,38 @@ module CanCan
       results
     end
 
+    def add_rule(rule)
+      @rules ||= Hash.new { |h, k| h[k] = [] }
+      @rules[:all] << rule if rule.subjects.compact.empty?
+      rule.subjects.each do |subject|
+        @rules[subject] << rule
+      end
+    end
+
+    def alternative_subjects(subject)
+      subject = subject.class unless subject.is_a?(Module)
+      descendants = []
+      [:all, *subject.ancestors, *descendants, subject.class.to_s]
+    end
+
     # Returns an array of Rule instances which match the action and subject
     # This does not take into consideration any hash conditions or block statements
     def relevant_rules(action, subject)
-      relevant = rules.select do |rule|
+      return [] unless @rules
+      relevant = possible_relevant_rules(subject).select do |rule|
         rule.expanded_actions = expand_actions(rule.actions)
         rule.relevant? action, subject
       end
-      relevant.reverse!
+      relevant.reverse!.uniq!
       relevant
+    end
+
+    def possible_relevant_rules(subject)
+      if subject.is_a?(Hash)
+        rules
+      else
+        @rules.values_at(subject, *alternative_subjects(subject)).flatten
+      end
     end
 
     def relevant_rules_for_match(action, subject)

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -246,10 +246,16 @@ module CanCan
     end
 
     def merge(ability)
-      ability.send(:rules).each do |rule|
+      ability.rules.each do |rule|
         rules << rule.dup
       end
       self
+    end
+
+    protected
+
+    def rules
+      @rules ||= []
     end
 
     private
@@ -300,10 +306,6 @@ module CanCan
         results += aliases_for_action(aliased_action) if actions.include? action
       end
       results
-    end
-
-    def rules
-      @rules ||= []
     end
 
     # Returns an array of Rule instances which match the action and subject

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -255,7 +255,7 @@ module CanCan
     protected
 
     def rules
-      @rules.values.flatten
+      @rules
     end
 
     private
@@ -309,10 +309,19 @@ module CanCan
     end
 
     def add_rule(rule)
-      @rules ||= Hash.new { |h, k| h[k] = [] }
-      @rules[:all] << rule if rule.subjects.compact.empty?
-      rule.subjects.each do |subject|
-        @rules[subject] << rule
+      @rules ||= []
+      @rules << rule
+      add_rule_to_index(rule, @rules.size - 1)
+    end
+
+    def add_rule_to_index(rule, position)
+      @rules_index ||= Hash.new { |h, k| h[k] = [] }
+
+      subjects = rule.subjects.compact
+      subjects << :all if subjects.empty?
+
+      subjects.each do |subject|
+        @rules_index[subject] << position
       end
     end
 
@@ -338,7 +347,9 @@ module CanCan
       if subject.is_a?(Hash)
         rules
       else
-        @rules.values_at(subject, *alternative_subjects(subject)).flatten
+        positions = @rules_index.values_at(subject, *alternative_subjects(subject))
+        positions.flatten!.sort!
+        positions.map { |i| @rules[i] }
       end
     end
 

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -91,7 +91,11 @@ module CanCan
     end
 
     def matches_subject_class?(subject)
-      @subjects.any? { |sub| sub.kind_of?(Module) && (subject.kind_of?(sub) || subject.class.to_s == sub.to_s || subject.kind_of?(Module) && subject.ancestors.include?(sub)) }
+      @subjects.any? do |sub|
+        sub.kind_of?(Module) && (subject.kind_of?(sub) ||
+                                 subject.class.to_s == sub.to_s ||
+                                 (subject.kind_of?(Module) && subject.ancestors.include?(sub)))
+      end
     end
 
     # Checks if the given subject matches the given conditions hash.

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -45,6 +45,13 @@ describe CanCan::Ability do
     expect(@ability.can?(:read, 6)).to be(false)
   end
 
+  it "overrides earlier rules with later ones (even if a different exact subject)" do
+    @ability.cannot :read, Numeric
+    @ability.can :read, Integer
+
+    expect(@ability.can?(:read, 6)).to be(true)
+  end
+
   it "does not pass class with object if :all objects are accepted" do
     @ability.can :preview, :all do |object|
       expect(object).to eq(123)


### PR DESCRIPTION
CanCan(Can)’s rule lookup time is currently abysmally slow with a non-small number of rules. This patch makes it ~300x faster with a large number of rules (see §Methodology & §Results below). This is accomplished by changing the time complexity of rule lookup from O(n) to O(1).

## Methodology

100 subjects, 5 actions each. No complex rules or queries. For more detail, see the actual [benchmarking scripts](https://gist.github.com/amarshall/babd7b51087c4d7577a7).

## Results

Some summary statistics (times in µs):

#### Before
<pre>
Read 3200 items
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
   8039   15130   16760   16190   19630   45760
</pre>

#### After
<pre>
Read 3200 items
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
  36.00   40.00   44.00   50.76   56.00  374.00
</pre>

#### Lookup time, constant rule numbers

![Box plot showing before/after comparison](https://cloud.githubusercontent.com/assets/153175/6063030/3aa8815e-ad22-11e4-8ec6-d9832d47d11c.png)
*Note the x-axis is in log scale.
(reproduce using [benchmark script](https://gist.github.com/amarshall/babd7b51087c4d7577a7#file-performance-single-rb))

#### Growth comparison

Varying the number of subjects clearly shows the change from O(n) → O(1):

![Line plot showing difference in time complexity with varying number of subjects](https://cloud.githubusercontent.com/assets/153175/6063036/41e09ed4-ad22-11e4-9407-d84a9c337473.png)
(reproduce using [benchmark script](https://gist.github.com/amarshall/babd7b51087c4d7577a7#file-performance-growth-rb))

It should be clear now these changes bring a significant performance benefit. On a large application (see §Testing for details about size). We’ve seen pages where CanCan(Can) consumed as much as 25% of the page load time be reduced to ~3%.

## Testing performed

Since this is no-doubt a significant change, these changes went through testing using the existing test suite of a relatively large application (~100k Ruby SLOC) with ~400 CanCan rules spanning ~1000 lines. Some issues were found using this, in particular the rule-ordering problem, for which a test has been added to CanCanCan. This is, of course, in addition to CanCanCan’s own test suite.