### PR TITLE
params[:controller] is never "camelized"

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -254,7 +254,7 @@ module CanCan
     end
 
     def namespace
-      @params[:controller].split(/::|\//)[0..-2]
+      @params[:controller].split('/')[0..-2]
     end
 
     def namespaced_name
@@ -264,7 +264,7 @@ module CanCan
     end
 
     def name_from_controller
-      @params[:controller].sub("Controller", "").underscore.split('/').last.singularize
+      @params[:controller].split('/').last.singularize
     end
 
     def instance_name

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -72,7 +72,7 @@ describe CanCan::ControllerResource do
         class Model < ::Model; end
       end
 
-      params.merge!(:controller => "MyEngine::ModelsController", :my_engine_model => {:name => "foobar"})
+      params.merge!(:controller => "my_engine/models", :my_engine_model => {:name => "foobar"})
       resource = CanCan::ControllerResource.new(controller)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq("foobar")
@@ -97,7 +97,7 @@ describe CanCan::ControllerResource do
     end
 
     it "builds a new resource for namespaced controller and namespaced model with hash if params[:id] is not specified" do
-      params.merge!(:controller => "Admin::SubModelsController", 'sub_model' => {:name => "foobar"})
+      params.merge!(:controller => "admin/sub_models", 'sub_model' => {:name => "foobar"})
       resource = CanCan::ControllerResource.new(controller, :class => Model)
       resource.load_resource
       expect(controller.instance_variable_get(:@sub_model).name).to eq("foobar")

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -307,30 +307,6 @@ describe CanCan::ControllerResource do
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
 
-    it "attempts to load a resource with the same namespace as the controller when using :: for namespace" do
-      module MyEngine
-        class Model < ::Model; end
-      end
-
-      model = MyEngine::Model.new
-      allow(MyEngine::Model).to receive(:find).with("123") { model }
-
-      params.merge!(:controller => "MyEngine::ModelsController")
-      resource = CanCan::ControllerResource.new(controller)
-      resource.load_resource
-      expect(controller.instance_variable_get(:@model)).to eq(model)
-    end
-
-    it "loads resource for namespaced controller when using '::' for namespace" do
-      model = Model.new
-      allow(Model).to receive(:find).with("123") { model }
-
-      params.merge!(:controller => "Admin::ModelsController")
-      resource = CanCan::ControllerResource.new(controller)
-      resource.load_resource
-      expect(controller.instance_variable_get(:@model)).to eq(model)
-    end
-
     it "performs authorization using controller action and loaded model" do
       controller.instance_variable_set(:@model, :some_model)
       allow(controller).to receive(:authorize!).with(:show, :some_model) { raise CanCan::AccessDenied }


### PR DESCRIPTION
I don't believe that `params[:controller]` ever comes in as a camelized string (like `MyEngine::ModelsController`). In every version of rails I know it is underscored (like `my_engine/models`). Please correct me if I am wrong on this.

This provides a tiny simplification to the ControllerResource class. If this can be merged I intend to do some further cleanup (using controller_name, splitting ControllerResource into multiple classes)