### PR TITLE
    Extract resource-loading logic from ControllerResource into another class.

### DIFF
--- a/lib/cancan.rb
+++ b/lib/cancan.rb
@@ -2,6 +2,7 @@ require "cancan/version"
 require 'cancan/ability'
 require 'cancan/rule'
 require 'cancan/controller_resource'
+require 'cancan/controller_resource/loader'
 require 'cancan/controller_additions'
 require 'cancan/model_additions'
 require 'cancan/exceptions'

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -107,7 +107,7 @@ module CanCan
 
     def parent_tuple
       [*@options[:through]].each do |name|
-        parent = fetch_parent(name)
+        parent = name && fetch_parent(name)
         return [name, parent] if parent
       end
       [nil, nil]

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -2,12 +2,19 @@ module CanCan
   # Handle the load and authorization controller logic so we don't clutter up all controllers with non-interface methods.
   # This class is used internally, so you do not need to call methods directly on it.
   class ControllerResource # :nodoc:
+    BEFORE_FILTER_PARAMS = [:only, :except, :if, :unless]
+
+    attr_reader :controller
+
     def self.add_before_filter(controller_class, method, *args)
       options = args.extract_options!
       resource_name = args.first
       before_filter_method = options.delete(:prepend) ? :prepend_before_filter : :before_filter
-      controller_class.send(before_filter_method, options.slice(:only, :except, :if, :unless)) do |controller|
-        controller.class.cancan_resource_class.new(controller, resource_name, options.except(:only, :except, :if, :unless)).send(method)
+
+      controller_class.__send__(before_filter_method, options.slice(*BEFORE_FILTER_PARAMS)) do |controller|
+        resource_options = options.except(*BEFORE_FILTER_PARAMS)
+        resource = controller.class.cancan_resource_class.new(controller, resource_name, resource_options)
+        resource.__send__(method)
       end
     end
 
@@ -16,9 +23,16 @@ module CanCan
       @params = controller.params
       @options = args.extract_options!
       @name = args.first
-      raise CanCan::ImplementationRemoved, "The :nested option is no longer supported, instead use :through with separate load/authorize call." if @options[:nested]
-      raise CanCan::ImplementationRemoved, "The :name option is no longer supported, instead pass the name as the first argument." if @options[:name]
-      raise CanCan::ImplementationRemoved, "The :resource option has been renamed back to :class, use false if no class." if @options[:resource]
+
+      if @options.has_key?(:nested)
+        raise CanCan::ImplementationRemoved, 'The :nested option is no longer supported, instead use :through with separate load/authorize call.'
+      end
+      if @options.has_key?(:name)
+        raise CanCan::ImplementationRemoved, 'The :name option is no longer supported, instead pass the name as the first argument.'
+      end
+      if @options.has_key?(:resource)
+        raise CanCan::ImplementationRemoved, 'The :resource option has been renamed back to :class, use false if no class.'
+      end
     end
 
     def load_and_authorize_resource
@@ -27,23 +41,27 @@ module CanCan
     end
 
     def load_resource
-      unless skip?(:load)
-        if load_instance?
-          self.resource_instance ||= load_resource_instance
-        elsif load_collection?
-          self.collection_instance ||= load_collection
-        end
-      end
+      return if skip?(:load)
+      loader.load_resource
     end
 
     def authorize_resource
-      unless skip?(:authorize)
-        @controller.authorize!(authorization_action, resource_instance || resource_class_with_parent)
-      end
+      return if skip?(:authorize)
+      @controller.authorize!(authorization_action, authorization_resource)
+    end
+
+    def authorization_action
+      parent? ? :show : controller_action
+    end
+
+    def authorization_resource
+      return resource_instance if resource_instance
+      return resource_class unless parent_resource
+      {parent_resource => resource_class}
     end
 
     def parent?
-      @options.has_key?(:parent) ? @options[:parent] : @name && @name != name_from_controller.to_sym
+      @options.fetch(:parent) { @name && @name != name_from_controller.to_sym }
     end
 
     def skip?(behavior)
@@ -54,87 +72,20 @@ module CanCan
       action_exists_in?(options[:only])
     end
 
-    protected
-
-    def load_resource_instance
-      if !parent? && new_actions.include?(@params[:action].to_sym)
-        build_resource
-      elsif id_param || @options[:singleton]
-        find_resource
-      end
+    def resource_instance=(instance)
+      @controller.instance_variable_set("@#{instance_name}", instance)
     end
 
-    def load_instance?
-      parent? || member_action?
+    def resource_instance
+      @controller.instance_variable_get("@#{instance_name}") if loader.load_instance?
     end
 
-    def load_collection?
-      resource_base.respond_to?(:accessible_by) && !current_ability.has_block?(authorization_action, resource_class)
+    def collection_instance=(collection)
+      @controller.instance_variable_set("@#{collection_name}", collection)
     end
 
-    def load_collection
-      resource_base.accessible_by(current_ability, authorization_action)
-    end
-
-    def build_resource
-      resource = resource_base.new(resource_params || {})
-      assign_attributes(resource)
-    end
-
-    def assign_attributes(resource)
-      resource.send("#{parent_name}=", parent_resource) if @options[:singleton] && parent_resource
-      initial_attributes.each do |attr_name, value|
-        resource.send("#{attr_name}=", value)
-      end
-      resource
-    end
-
-    def initial_attributes
-      current_ability.attributes_for(@params[:action].to_sym, resource_class).delete_if do |key, value|
-        resource_params && resource_params.include?(key)
-      end
-    end
-
-    def find_resource
-      if @options[:singleton] && parent_resource.respond_to?(name)
-        parent_resource.send(name)
-      else
-        if @options[:find_by]
-          if resource_base.respond_to? "find_by_#{@options[:find_by]}!"
-            resource_base.send("find_by_#{@options[:find_by]}!", id_param)
-          elsif resource_base.respond_to? "find_by"
-            resource_base.send("find_by", { @options[:find_by].to_sym => id_param })
-          else
-            resource_base.send(@options[:find_by], id_param)
-          end
-        else
-          adapter.find(resource_base, id_param)
-        end
-      end
-    end
-
-    def adapter
-      ModelAdapters::AbstractAdapter.adapter_class(resource_class)
-    end
-
-    def authorization_action
-      parent? ? :show : @params[:action].to_sym
-    end
-
-    def id_param
-      @params[id_param_key].to_s if @params[id_param_key]
-    end
-
-    def id_param_key
-      if @options[:id_param]
-        @options[:id_param]
-      else
-        parent? ? :"#{name}_id" : :id
-      end
-    end
-
-    def member_action?
-      new_actions.include?(@params[:action].to_sym) || @options[:singleton] || ( (@params[:id] || @params[@options[:id_param]]) && !collection_actions.include?(@params[:action].to_sym))
+    def collection_instance
+      @controller.instance_variable_get("@#{collection_name}")
     end
 
     # Returns the class used for this resource. This can be overriden by the :class option.
@@ -149,148 +100,60 @@ module CanCan
       end
     end
 
-    def resource_class_with_parent
-      parent_resource ? {parent_resource => resource_class} : resource_class
-    end
-
-    def resource_instance=(instance)
-      @controller.instance_variable_set("@#{instance_name}", instance)
-    end
-
-    def resource_instance
-      @controller.instance_variable_get("@#{instance_name}") if load_instance?
-    end
-
-    def collection_instance=(instance)
-      @controller.instance_variable_set("@#{instance_name.to_s.pluralize}", instance)
-    end
-
-    def collection_instance
-      @controller.instance_variable_get("@#{instance_name.to_s.pluralize}")
-    end
-
-    # The object that methods (such as "find", "new" or "build") are called on.
-    # If the :through option is passed it will go through an association on that instance.
-    # If the :shallow option is passed it will use the resource_class if there's no parent
-    # If the :singleton option is passed it won't use the association because it needs to be handled later.
-    def resource_base
-      if @options[:through]
-        if parent_resource
-          base = @options[:singleton] ? resource_class : parent_resource.send(@options[:through_association] || name.to_s.pluralize)
-          base = base.scoped if base.respond_to?(:scoped) && defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 3
-          base
-        elsif @options[:shallow]
-          resource_class
-        else
-          raise AccessDenied.new(nil, authorization_action, resource_class) # maybe this should be a record not found error instead?
-        end
-      else
-        resource_class
-      end
-    end
-
-    def parent_name
-      @options[:through] && [@options[:through]].flatten.detect { |i| fetch_parent(i) }
-    end
-
     # The object to load this resource through.
     def parent_resource
-      parent_name && fetch_parent(parent_name)
+      parent_tuple.last
+    end
+
+    def parent_tuple
+      [*@options[:through]].each do |name|
+        parent = fetch_parent(name)
+        return [name, parent] if parent
+      end
+      [nil, nil]
     end
 
     def fetch_parent(name)
       if @controller.instance_variable_defined? "@#{name}"
         @controller.instance_variable_get("@#{name}")
       elsif @controller.respond_to?(name, true)
-        @controller.send(name)
+        @controller.__send__(name)
       end
     end
 
-    def current_ability
-      @controller.send(:current_ability)
+    def namespaced_name
+      controller_namespace = @params[:controller].split(/::|\//)[0..-2]
+      [controller_namespace, name.camelize].flatten.map(&:camelize).join('::').singularize.constantize
+    rescue NameError
+      name
+    end
+
+    def controller_action
+      @params[:action].to_sym
     end
 
     def name
       @name || name_from_controller
     end
 
-    def resource_params
-      if parameters_require_sanitizing? && params_method.present?
-        return case params_method
-          when Symbol then @controller.send(params_method)
-          when String then @controller.instance_eval(params_method)
-          when Proc then params_method.call(@controller)
-        end
-      else
-        resource_params_by_namespaced_name
-      end
-    end
-
-    def parameters_require_sanitizing?
-      save_actions.include?(@params[:action].to_sym) || resource_params_by_namespaced_name.present?
-    end
-
-    def resource_params_by_namespaced_name
-      if @options[:instance_name] && @params.has_key?(extract_key(@options[:instance_name]))
-        @params[extract_key(@options[:instance_name])]
-      elsif @options[:class] && @params.has_key?(extract_key(@options[:class]))
-        @params[extract_key(@options[:class])]
-      else
-        @params[extract_key(namespaced_name)]
-      end
-    end
-
-    def params_method
-      params_methods.each do |method|
-        return method if (method.is_a?(Symbol) && @controller.respond_to?(method, true)) || method.is_a?(String) || method.is_a?(Proc)
-      end
-      nil
-    end
-
-    def params_methods
-      methods = ["#{@params[:action]}_params".to_sym, "#{name}_params".to_sym, :resource_params]
-      methods.unshift(@options[:param_method]) if @options[:param_method].present?
-      methods
-    end
-
-    def namespace
-      @params[:controller].split(/::|\//)[0..-2]
-    end
-
-    def namespaced_name
-      [namespace, name.camelize].flatten.map(&:camelize).join('::').singularize.constantize
-    rescue NameError
-      name
-    end
-
     def name_from_controller
-      @params[:controller].sub("Controller", "").underscore.split('/').last.singularize
+      @params[:controller].sub('Controller', '').underscore.split('/').last.singularize
     end
 
     def instance_name
-      @options[:instance_name] || name
+      @options.fetch(:instance_name) { name }
     end
 
-    def collection_actions
-      [:index] + Array(@options[:collection])
+    def collection_name
+      instance_name.to_s.pluralize
     end
-
-    def new_actions
-      [:new, :create] + Array(@options[:new])
-    end
-
-    def save_actions
-      [:create, :update]
-    end
-
-    private
 
     def action_exists_in?(options)
       Array(options).include?(@params[:action].to_sym)
     end
 
-    def extract_key(value)
-       value.to_s.underscore.gsub('/', '_')
+    def loader
+      @loader ||= Loader.new(self, @params, @options)
     end
   end
 end

--- a/lib/cancan/controller_resource/loader.rb
+++ b/lib/cancan/controller_resource/loader.rb
@@ -1,0 +1,172 @@
+module CanCan
+  class ControllerResource
+
+    class Loader
+      COLLECTION_ACTIONS = [:index]
+      NEW_ACTIONS        = [:new, :create]
+      SAVE_ACTIONS       = [:create, :update]
+
+      def initialize(controller_resource, params, options)
+        @resource = controller_resource
+        @params   = params
+        @options  = options
+      end
+
+      def load_resource
+        if load_instance?
+          @resource.resource_instance ||= load_resource_instance
+        elsif load_collection?
+          @resource.collection_instance ||= load_collection_instance
+        end
+      end
+
+      def load_collection?
+       resource_base.respond_to?(:accessible_by) && !current_ability.has_block?(@resource.authorization_action, @resource.resource_class)
+      end
+
+      def load_instance?
+        @resource.parent? || member_action?
+      end
+
+      private
+
+      def load_collection_instance
+       resource_base.accessible_by(current_ability, @resource.authorization_action)
+      end
+
+      def load_resource_instance
+        if !@resource.parent? && new_action?
+          build_resource_instance
+        elsif id_param || @options[:singleton]
+          find_resource_instance
+        end
+      end
+
+      def find_resource_instance
+        if @options[:singleton] && @resource.parent_resource.respond_to?(@resource.name)
+          return @resource.parent_resource.__send__(@resource.name)
+        end
+
+        return adapter.find(resource_base, id_param) unless @options.has_key?(:find_by)
+        find_by_attribute = @options[:find_by]
+
+        if resource_base.respond_to?("find_by_#{find_by_attribute}!")
+         resource_base.__send__("find_by_#{find_by_attribute}!", id_param)
+        elsif resource_base.respond_to?(:find_by)
+         resource_base.__send__(:find_by, {find_by_attribute.to_sym => id_param})
+        else
+         resource_base.__send__(find_by_attribute, id_param)
+        end
+      end
+
+      def adapter
+        ModelAdapters::AbstractAdapter.adapter_class(@resource.resource_class)
+      end
+
+      def build_resource_instance
+        instance = resource_base.new(resource_params || {})
+        assign_attributes(instance)
+      end
+
+      def assign_attributes(instance)
+        if @options[:singleton] && @resource.parent_resource
+          instance.__send__("#{@resource.parent_tuple.first}=", @resource.parent_resource)
+        end
+
+        current_ability.attributes_for(@resource.controller_action, @resource.resource_class).each do |key, value|
+          unless resource_params && resource_params.include?(key)
+            instance.__send__("#{key}=", value)
+          end
+        end
+        instance
+      end
+
+      # The object that methods (such as "find", "new" or "build") are called on.
+      # If the :through option is passed it will go through an association on that instance.
+      # If the :shallow option is passed it will use the resource_class if there's no parent
+      # If the :singleton option is passed it won't use the association because it needs to be handled later.
+      def resource_base
+        return @resource.resource_class unless @options.has_key?(:through)
+
+        if @resource.parent_resource
+          through_association = @options.fetch(:through_association) { @resource.name.to_s.pluralize }
+          base = @options[:singleton] ? @resource.resource_class : @resource.parent_resource.__send__(through_association)
+          base = base.scoped if base.respond_to?(:scoped) && defined?(ActiveRecord) && ActiveRecord::VERSION::MAJOR == 3
+          base
+        elsif @options[:shallow]
+          @resource.resource_class
+        else
+          raise AccessDenied.new(nil, @resource.authorization_action, @resource.resource_class) # maybe this should be a record not found error instead?
+        end
+      end
+
+      def resource_params
+        unless parameters_require_sanitizing? && params_method.present?
+          return resource_params_by_namespaced_name
+        end
+
+        case params_method
+        when Symbol then @resource.controller.__send__(params_method)
+        when String then @resource.controller.instance_eval(params_method)
+        when Proc   then params_method.call(@resource.controller)
+        end
+      end
+
+      def parameters_require_sanitizing?
+        save_action? || resource_params_by_namespaced_name.present?
+      end
+
+      def resource_params_by_namespaced_name
+        [:instance_name, :class].each do |param|
+          option = @options[param]
+          return @params[extract_key(option)] if option && @params.has_key?(extract_key(option))
+        end
+        @params[extract_key(@resource.namespaced_name)]
+      end
+
+      def params_method
+        methods = ["#{@resource.controller_action}_params".to_sym, "#{@resource.name}_params".to_sym, :resource_params]
+        methods.unshift(@options[:param_method]) if @options.has_key?(:param_method)
+
+        methods.detect do |method|
+          (method.is_a?(Symbol) && @resource.controller.respond_to?(method, true)) || method.is_a?(String) || method.is_a?(Proc)
+        end
+      end
+
+      def member_action?
+        return true if new_action? || @options[:singleton]
+        id_param = @options.fetch(:id_param, :id)
+        @params.has_key?(id_param) && !collection_action?
+      end
+
+      def id_param
+        key = @options.fetch(:id_param) { @resource.parent? ? :"#{@resource.name}_id" : :id }
+        value = @params[key]
+        value && value.to_s
+      end
+
+      def collection_action?
+        actions = COLLECTION_ACTIONS + [*@options[:collection]]
+        actions.include?(@resource.controller_action)
+      end
+
+      def new_action?
+        actions = NEW_ACTIONS + [*@options[:new]]
+        actions.include?(@resource.controller_action)
+      end
+
+      def save_action?
+        SAVE_ACTIONS.include?(@resource.controller_action)
+      end
+
+      def current_ability
+        @resource.controller.__send__(:current_ability)
+      end
+
+      def extract_key(value)
+        value.to_s.underscore.gsub('/', '_')
+      end
+    end
+
+  end
+end

--- a/lib/cancan/inherited_resource.rb
+++ b/lib/cancan/inherited_resource.rb
@@ -1,20 +1,26 @@
 module CanCan
   # For use with Inherited Resources
   class InheritedResource < ControllerResource # :nodoc:
-    def load_resource_instance
-      if parent?
-        @controller.send :association_chain
-        @controller.instance_variable_get("@#{instance_name}")
-      elsif new_actions.include? @params[:action].to_sym
-        resource = @controller.send :build_resource
-        assign_attributes(resource)
-      else
-        @controller.send :resource
-      end
+    def loader
+      @loader ||= InheritedResource::Loader.new(self, @params, @options)
     end
 
     def resource_base
-      @controller.send :end_of_association_chain
+      @controller.__send__(:end_of_association_chain)
+    end
+
+    class Loader < ControllerResource::Loader
+      def load_resource_instance
+        if @resource.parent?
+          @resource.controller.__send__(:association_chain)
+          @resource.controller.instance_variable_get("@#{@resource.instance_name}")
+        elsif new_action?
+          instance = @resource.controller.__send__(:build_resource)
+          assign_attributes(instance)
+        else
+          @resource.controller.__send__(:resource)
+        end
+      end
     end
   end
 end

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -146,17 +146,17 @@ describe CanCan::ControllerResource do
         allow(controller).to receive(:create_params).and_return(:create => 'params')
         allow(controller).to receive(:custom_params).and_return(:custom => 'params')
         resource = CanCan::ControllerResource.new(controller, {:param_method => :custom_params})
-        expect(resource.send("resource_params")).to eq(:custom => 'params')
+        expect(resource.loader.send("resource_params")).to eq(:custom => 'params')
       end
 
       it "accepts the specified string for sanitizing input" do
         resource = CanCan::ControllerResource.new(controller, {:param_method => "{:custom => 'params'}"})
-        expect(resource.send("resource_params")).to eq(:custom => 'params')
+        expect(resource.loader.send("resource_params")).to eq(:custom => 'params')
       end
 
       it "accepts the specified proc for sanitizing input" do
         resource = CanCan::ControllerResource.new(controller, {:param_method => Proc.new { |c| {:custom => 'params'}}})
-        expect(resource.send("resource_params")).to eq(:custom => 'params')
+        expect(resource.loader.send("resource_params")).to eq(:custom => 'params')
       end
 
       it "prefers to use the create_params method for santitizing input" do
@@ -165,7 +165,7 @@ describe CanCan::ControllerResource do
         allow(controller).to receive(:create_params).and_return(:create => 'params')
         allow(controller).to receive(:custom_params).and_return(:custom => 'params')
         resource = CanCan::ControllerResource.new(controller)
-        expect(resource.send("resource_params")).to eq(:create => 'params')
+        expect(resource.loader.send("resource_params")).to eq(:create => 'params')
       end
 
       it "prefers to use the <model_name>_params method for santitizing input if create is not found" do
@@ -173,14 +173,14 @@ describe CanCan::ControllerResource do
         allow(controller).to receive(:model_params).and_return(:model => 'params')
         allow(controller).to receive(:custom_params).and_return(:custom => 'params')
         resource = CanCan::ControllerResource.new(controller)
-        expect(resource.send("resource_params")).to eq(:model => 'params')
+        expect(resource.loader.send("resource_params")).to eq(:model => 'params')
       end
 
       it "prefers to use the resource_params method for santitizing input if create or model is not found" do
         allow(controller).to receive(:resource_params).and_return(:resource => 'params')
         allow(controller).to receive(:custom_params).and_return(:custom => 'params')
         resource = CanCan::ControllerResource.new(controller)
-        expect(resource.send("resource_params")).to eq(:resource => 'params')
+        expect(resource.loader.send("resource_params")).to eq(:resource => 'params')
       end
     end
   end
@@ -487,13 +487,13 @@ describe CanCan::ControllerResource do
     it "always converts id param to string" do
       params.merge!(:the_model => { :malicious => "I am" })
       resource = CanCan::ControllerResource.new(controller, :id_param => :the_model)
-      expect(resource.send(:id_param).class).to eq(String)
+      expect(resource.loader.send(:id_param).class).to eq(String)
     end
 
     it "should id param return nil if param is nil" do
       params.merge!(:the_model => nil)
       resource = CanCan::ControllerResource.new(controller, :id_param => :the_model)
-      expect(resource.send(:id_param)).to be_nil
+      expect(resource.loader.send(:id_param)).to be_nil
     end
 
     it "loads resource using custom find_by attribute" do


### PR DESCRIPTION
I was reading the source of `ControllerResource` to try to understand why an `authorize_resource` macro in our controller was authorizing a different resource than the one we expected. I found it quite hard to see what was going on, because all the logic for `load_resource` is mixed into the same class as that for `authorize_resource`.

This commit extracts all the loading logic into a new class called `ControllerResource::Loader`, and refactors some internal APIs in the process to support the interaction between `Loader` and `ControllerResource`. These refactorings include:
- Extracing values that are a matter of definition (e.g. the options to `before_filter` and the lists of types of actions) into named constants.
- Pulling some repeated expressions into their own methods, e.g. `controller_action` and `collection_name`.
- Inlining some methods that are only called from one place, e.g. `initial_attributes`, `id_param_key`, `resource_class_with_parent`, `params_methods`, `namespace`.
- Eliminate some overly long expressions, and reduce complexity of a few methods by flattening conditional blocks.
- Using `__send__` rather than `send` to avoid accidentally calling user-defined domain methods called `send`.
