### PR TITLE
We must assign resource_instance before asking the controlller for resource_params

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -77,7 +77,8 @@ module CanCan
     end
 
     def build_resource
-      resource = resource_base.new(resource_params || {})
+      self.resource_instance = resource = resource_base.new
+      resource.attributes = resource_params || {}
       assign_attributes(resource)
     end
 

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -15,6 +15,12 @@ describe CanCan::ControllerResource do
           send("#{attribute}=", value)
         end
       end
+
+      def attributes=(attributes={})
+        attributes.each do |attribute, value|
+          send("#{attribute}=", value)
+        end
+      end
     end
 
     allow(controller).to receive(:params) { params }
@@ -44,10 +50,11 @@ describe CanCan::ControllerResource do
 
     it "builds a resource when on custom new action even when params[:id] exists" do
       params.merge!(:action => "build", :id => "123")
-      allow(Model).to receive(:new) { :some_model }
+      some_model = Model.new
+      allow(Model).to receive(:new) { some_model }
       resource = CanCan::ControllerResource.new(controller, :new => :build)
       resource.load_resource
-      expect(controller.instance_variable_get(:@model)).to eq(:some_model)
+      expect(controller.instance_variable_get(:@model)).to eq(some_model)
     end
 
     it "only authorizes :show action on parent resource" do

--- a/spec/cancan/inherited_resource_spec.rb
+++ b/spec/cancan/inherited_resource_spec.rb
@@ -15,6 +15,12 @@ describe CanCan::InheritedResource do
           send("#{attribute}=", value)
         end
       end
+
+      def attributes=(attributes={})
+        attributes.each do |attribute, value|
+          send("#{attribute}=", value)
+        end
+      end
     end
 
     allow(controller).to receive(:params) { params }


### PR DESCRIPTION
Sometimes (as in my case) the controller calculates the list of allowed fields in resource_params based on the current_user abilities. The latter needs the resource to be instantiated. But it turned out that it is not done for new_actions.
The commit fixes the situation.