### PR TITLE
Negative conditions for ActiveRecord 4

### DIFF
--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -2,8 +2,23 @@ module CanCan
   module ModelAdapters
     class ActiveRecord4Adapter < AbstractAdapter
       include ActiveRecordAdapter
-      def self.for_class?(model_class)
-        model_class <= ActiveRecord::Base
+
+      class << self
+        def for_class?(model_class)
+          model_class <= ActiveRecord::Base
+        end
+
+        def override_condition_matching?(subject, name, value)
+          name == :not || super
+        end
+
+        def matches_condition?(subject, name, value)
+          if name == :not && value.kind_of?(Hash)
+            value.none? {|attribute, test| subject.send(attribute) == test }
+          else
+            super
+          end
+        end
       end
 
       private

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -30,7 +30,7 @@ module CanCan
       def tableized_conditions(conditions, model_class = @model_class)
         return conditions unless conditions.kind_of? Hash
         conditions.inject({}) do |result_hash, (name, value)|
-          if value.kind_of? Hash
+          if association_condition? name, value
             value = value.dup
             association_class = model_class.reflect_on_association(name).klass.name.constantize
             nested = value.inject({}) do |nested,(k,v)|
@@ -75,6 +75,10 @@ module CanCan
       end
 
       private
+
+      def association_condition?(name, value)
+        value.kind_of? Hash
+      end
 
       def mergeable_conditions?
         @rules.find {|rule| rule.unmergeable? }.blank?

--- a/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
@@ -6,36 +6,40 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
       before :each do
         ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
         ActiveRecord::Migration.verbose = false
-        ActiveRecord::Schema.define do
-          create_table(:parents) do |t|
-            t.timestamps :null => false
-          end
-
-          create_table(:children) do |t|
-            t.timestamps :null => false
-            t.integer :parent_id
-          end
-        end
-
-        class Parent < ActiveRecord::Base
-          has_many :children, lambda { order(:id => :desc) }
-        end
-
-        class Child < ActiveRecord::Base
-          belongs_to :parent
-        end
-
         (@ability = double).extend(CanCan::Ability)
       end
 
-      it "respects scope on included associations" do
-        @ability.can :read, [Parent, Child]
+      context 'associations' do
+        before :each do
+          ActiveRecord::Schema.define do
+            create_table(:parents) do |t|
+              t.timestamps :null => false
+            end
 
-        parent = Parent.create!
-        child1 = Child.create!(:parent => parent, :created_at => 1.hours.ago)
-        child2 = Child.create!(:parent => parent, :created_at => 2.hours.ago)
+            create_table(:children) do |t|
+              t.timestamps :null => false
+              t.integer :parent_id
+            end
+          end
 
-        expect(Parent.accessible_by(@ability).order(:created_at => :asc).includes(:children).first.children).to eq [child2, child1]
+          class Parent < ActiveRecord::Base
+            has_many :children, lambda { order(:id => :desc) }
+          end
+
+          class Child < ActiveRecord::Base
+            belongs_to :parent
+          end
+        end
+
+        it "respects scope on included associations" do
+          @ability.can :read, [Parent, Child]
+
+          parent = Parent.create!
+          child1 = Child.create!(:parent => parent, :created_at => 1.hours.ago)
+          child2 = Child.create!(:parent => parent, :created_at => 2.hours.ago)
+
+          expect(Parent.accessible_by(@ability).order(:created_at => :asc).includes(:children).first.children).to eq [child2, child1]
+        end
       end
     end
 

--- a/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
@@ -41,6 +41,31 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
           expect(Parent.accessible_by(@ability).order(:created_at => :asc).includes(:children).first.children).to eq [child2, child1]
         end
       end
+
+      context 'conditions' do
+        before :each do
+          ActiveRecord::Schema.define do
+            create_table(:records) do |t|
+              t.timestamps :null => false
+              t.string :name
+            end
+          end
+
+          class Record < ActiveRecord::Base
+          end
+        end
+
+        it 'uses :not for negative conditions' do
+          @ability.can :read, Record, :not => {:name => 'unreadable'}
+
+          unreadable = Record.create! :name => 'unreadable'
+          readable = Record.create! :name => 'readable'
+
+          accessible = Record.accessible_by(@ability)
+          expect(accessible).to include readable
+          expect(accessible).not_to include unreadable
+        end
+      end
     end
 
     if Gem::Specification.find_all_by_name('pg').any?


### PR DESCRIPTION
Support negative conditions (`where.not`) for ActiveRecord 4. Usage: `can :read, Model, not: {name: 'foo'}`. See #191 for discussion.