### PR TITLE
Support ActiveRecord 4.x enums

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,6 @@
 Develop
 
+* Fix cancancan#102 - Support for ActiveRecord 4.x enums (markpmitchell)
 
 1.10.1 (January 13th, 2015)
 

--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -18,6 +18,21 @@ module CanCan
         relation
       end
 
+      def self.override_condition_matching?(subject, name, value)
+        subject.class.defined_enums.include? name.to_s
+      end
+
+      def self.matches_condition?(subject, name, value)
+        # Get the mapping from enum strings to values.
+        enum = subject.class.send(name.to_s.pluralize)
+        # Get the value of the attribute as an integer.
+        attribute = enum[subject.send(name)]
+        # Check to see if the value matches the condition.
+        value.is_a?(Enumerable) ? 
+          (value.include? attribute) :
+          attribute == value
+      end
+
       # Rails 4.2 deprecates `sanitize_sql_hash_for_conditions`
       def sanitize_sql(conditions)
         if ActiveRecord::VERSION::MINOR >= 2 && Hash === conditions

--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -19,7 +19,9 @@ module CanCan
       end
 
       def self.override_condition_matching?(subject, name, value)
-        subject.class.defined_enums.include? name.to_s
+        # ActiveRecord introduced enums in version 4.1.
+        ActiveRecord::VERSION::MINOR >= 1 &&
+          subject.class.defined_enums.include?(name.to_s)
       end
 
       def self.matches_condition?(subject, name, value)

--- a/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
@@ -38,41 +38,43 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
         expect(Parent.accessible_by(@ability).order(:created_at => :asc).includes(:children).first.children).to eq [child2, child1]
       end
 
-      it "allows filters on enums" do
-        ActiveRecord::Schema.define do
-          create_table(:shapes) do |t|
-            t.integer :color, default: 0, null: false
+      if ActiveRecord::VERSION::MINOR >= 1
+        it "allows filters on enums" do
+          ActiveRecord::Schema.define do
+            create_table(:shapes) do |t|
+              t.integer :color, default: 0, null: false
+            end
           end
+
+          class Shape < ActiveRecord::Base
+            enum color: [:red, :green, :blue]
+          end
+
+          red = Shape.create!(color: :red)
+          green = Shape.create!(color: :green)
+          blue = Shape.create!(color: :blue)
+
+          # A condition with a single value.
+          @ability.can :read, Shape, color: Shape.colors[:green]
+
+          expect(@ability.cannot? :read, red).to be true
+          expect(@ability.can? :read, green).to be true
+          expect(@ability.cannot? :read, blue).to be true
+
+          accessible = Shape.accessible_by(@ability)
+          expect(accessible).to contain_exactly(green)
+
+          # A condition with multiple values.
+          @ability.can :update, Shape, color: [Shape.colors[:red],
+                                               Shape.colors[:blue]]
+
+          expect(@ability.can? :update, red).to be true
+          expect(@ability.cannot? :update, green).to be true
+          expect(@ability.can? :update, blue).to be true
+
+          accessible = Shape.accessible_by(@ability, :update)
+          expect(accessible).to contain_exactly(red, blue)
         end
-        
-        class Shape < ActiveRecord::Base
-          enum color: [:red, :green, :blue]
-        end
-
-        red = Shape.create!(color: :red)
-        green = Shape.create!(color: :green)
-        blue = Shape.create!(color: :blue)
-
-        # A condition with a single value.
-        @ability.can :read, Shape, color: Shape.colors[:green]
-
-        expect(@ability.cannot? :read, red).to be true
-        expect(@ability.can? :read, green).to be true
-        expect(@ability.cannot? :read, blue).to be true
-
-        accessible = Shape.accessible_by(@ability)
-        expect(accessible).to contain_exactly(green)
-
-        # A condition with multiple values.
-        @ability.can :update, Shape, color: [Shape.colors[:red],
-                                             Shape.colors[:blue]]
-
-        expect(@ability.can? :update, red).to be true
-        expect(@ability.cannot? :update, green).to be true
-        expect(@ability.can? :update, blue).to be true
-
-        accessible = Shape.accessible_by(@ability, :update)
-        expect(accessible).to contain_exactly(red, blue)
       end
     end
 

--- a/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
@@ -42,20 +42,20 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
         it "allows filters on enums" do
           ActiveRecord::Schema.define do
             create_table(:shapes) do |t|
-              t.integer :color, default: 0, null: false
+              t.integer :color, :default => 0, :null => false
             end
           end
 
           class Shape < ActiveRecord::Base
-            enum color: [:red, :green, :blue]
+            enum :color => [:red, :green, :blue]
           end
 
-          red = Shape.create!(color: :red)
-          green = Shape.create!(color: :green)
-          blue = Shape.create!(color: :blue)
+          red = Shape.create!(:color => :red)
+          green = Shape.create!(:color => :green)
+          blue = Shape.create!(:color => :blue)
 
           # A condition with a single value.
-          @ability.can :read, Shape, color: Shape.colors[:green]
+          @ability.can :read, Shape, :color => Shape.colors[:green]
 
           expect(@ability.cannot? :read, red).to be true
           expect(@ability.can? :read, green).to be true
@@ -65,8 +65,8 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
           expect(accessible).to contain_exactly(green)
 
           # A condition with multiple values.
-          @ability.can :update, Shape, color: [Shape.colors[:red],
-                                               Shape.colors[:blue]]
+          @ability.can :update, Shape, :color => [Shape.colors[:red],
+                                                  Shape.colors[:blue]]
 
           expect(@ability.can? :update, red).to be true
           expect(@ability.cannot? :update, green).to be true


### PR DESCRIPTION
Fixes Issue #102 

ActiveRecord queries for records with enums are by integer value, not by symbol. As CanCan uses the same query syntax, the way to specify a condition based on enum values is like so:

  can :read, Shape, color: Shape.colors[:blue]

While CanCan already generated the correct SQL queries for accessible_by, checks against individual objects did not work because the value of an enum attribute is a String. Therefore, the ActiveRecord 4 adapter must special case matches_condition? to convert the String to the appropriate integer before comparing against the value provided in the condition.
