### PR TITLE
Reduce unnecessary allocations in Rule creation

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -14,8 +14,8 @@ module CanCan
       raise Error, "You are not able to supply a block with a hash of conditions in #{action} #{subject} ability. Use either one." if conditions.kind_of?(Hash) && !block.nil?
       @match_all = action.nil? && subject.nil?
       @base_behavior = base_behavior
-      @actions = [action].flatten
-      @subjects = [subject].flatten
+      @actions = Array(action)
+      @subjects = Array(subject)
       @conditions = conditions || {}
       @block = block
     end


### PR DESCRIPTION
# Background

I was profiling our company's API with Stackprof to track down high memory usage issues that we have somewhere. CanCan::Rule.initialize came in as the top allocator of Objects:

```
==================================
  Mode: object(1000)
  Samples: 10680 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       927   (8.7%)         654   (6.1%)     CanCan::Rule#initialize
       404   (3.8%)         404   (3.8%)     block in CanCan::Rule#matches_subject_class?
       365   (3.4%)         365   (3.4%)     block in <class:TransactionMetrics>
       313   (2.9%)         313   (2.9%)     NewRelic::CollectionHelper#flatten
       279   (2.6%)         229   (2.1%)     JSON#generate
       189   (1.8%)         189   (1.8%)     block in NewRelic::Agent::StatsHash#merge_transaction_metrics!
      1251  (11.7%)         188   (1.8%)     ActiveSupport::JSON::Encoding::JSONGemEncoder#jsonify
       273   (2.6%)         182   (1.7%)     ActiveRecord::DynamicMatchers::Method.match
       486   (4.6%)         180   (1.7%)     block in ActionDispatch::Http::FilterParameters#filtered_query_string
       220   (2.1%)         180   (1.7%)     ActionDispatch::Http::ParameterFilter::CompiledFilter.compile
```

Digging in a bit more with Stackprof, I found the offending lines:

```
                                  |    13  |     def initialize(base_behavior, action, subject, conditions, block)
                                  |    14  |       raise Error, "You are not able to supply a block with a hash of conditions in #{action} #{subject} ability. Use either one." if conditions.kind_of?(Hash) && !block.nil?
                                  |    15  |       @match_all = action.nil? && subject.nil?
                                  |    16  |       @base_behavior = base_behavior
  282    (2.6%) /   282   (2.6%)  |    17  |       @actions = [action].flatten
  555    (5.2%) /   282   (2.6%)  |    18  |       @subjects = [subject].flatten
   90    (0.8%) /    90   (0.8%)  |    19  |       @conditions = conditions || {}
                                  |    20  |       @block = block
                                  |    21  |     end
```

The pattern of doing `[var].flatten` to coerce values to Arrays makes
three Array allocations every time. The first is for the array enclosing
var, the other two are in the C implementation of `flatten` to perform a
depth-first traversal over any nested arrays found within the outer-most
array[1]. Rules are allocated a _lot_ during the typical execution of an
application using CanCanCan for authorization. Since the parameters to
Ability#can are expected to not be deeply nested, we can cut out the
extra allocations by using Kernel#Array. This benchmark:

```
[Array#flatten] Mem diff: 18.40625 MB
[Kernel#Array] Mem diff: 1.01953125 MB
```

Shows a savings of 17MB of allocations when instantiating 10,000
Rules[2].
This translates to a 2x speed improvement in Rule instantiation time:

```
Calculating -------------------------------------
       Array#flatten    16.147k i/100ms
        Kernel#Array    34.565k i/100ms
-------------------------------------------------
       Array#flatten    218.381k (± 9.7%) i/s -      1.098M
        Kernel#Array    460.892k (±30.7%) i/s -      2.108M

Comparison:
        Kernel#Array:   460892.2 i/s
       Array#flatten:   218380.6 i/s - 2.11x slower
```
# Known Issues

If there are users out there doing something like

``` ruby
default_perms = [:read, :write]
can [default_params, :delete], :things
```

then this will probably be a breaking change. I don't believe the migration path should be that bad... it should be no more than chaining on your own call to flatten like `can [default_params, :delete].flatten, :things`. You sacrifice the performance, but remain compatible.

# Miscellany

[1] The first array used by flatten is a stack to push sub-arrays onto
while traversing, the second is for the result array. See https://github.com/ruby/ruby/blob/trunk/array.c#L4385-L4386 

[2] Memory figures are RSS, which doesn't consider shared memory, but we
have none for this simple benchmark. GC was disabled during the
benchmark eliminate the effects of unpredictable GC activity. Most of
the intermediary arrays are immediately garbage, but the act of
allocating them increases the work the garbage collector has to do.
Benchmark/ips was used with GC enabled in the second benchmark.
Benchmark script used is available here:
https://gist.github.com/timraymond/8d7014e0c7804f0fe508