### PR TITLE
Update travis to use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 1.8.7
   - 1.9.2
@@ -21,6 +24,7 @@ gemfile:
 services:
   - mongodb
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: rbx
     - rvm: jruby


### PR DESCRIPTION
The Travis build config can be updated to allow the tests to run on their container-based infrastructure.
http://docs.travis-ci.com/user/migrating-from-legacy/

This lets the tests start faster and run quicker. This PR should be compatible with #230 which would also be great to get merged.
