### PR TITLE
fixing example of authorize of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `authorize!` method in the controller will raise an exception if the user is
 ```ruby
 def show
   @article = Article.find(params[:id])
-  authorize! :read, @article
+  authorize! :show, @article
 end
 ```
 


### PR DESCRIPTION
i think that in the example of `authorize!`, the first variable should have the same name of the method where is executed. It keeps more easy to understand `authorize! :show, @article` instead of `authorize! :read, @article`