### PR TITLE
Allow Symbol or Proc to define model class

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -149,6 +149,8 @@ module CanCan
       when false  then name.to_sym
       when nil    then namespaced_name.to_s.camelize.constantize
       when String then @options[:class].constantize
+      when Symbol then @controller.send(@options[:class])
+      when Proc   then @options[:class].call(@controller)
       else @options[:class]
       end
     end

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -441,6 +441,25 @@ describe CanCan::ControllerResource do
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
 
+    it "loads the model using a symbol" do
+      model = Model.new
+      allow(Model).to receive(:find).with("123") { model }
+      allow(controller).to receive(:model) { Model }
+
+      resource = CanCan::ControllerResource.new(controller, :class => :model)
+      resource.load_resource
+      expect(controller.instance_variable_get(:@model)).to eq(model)
+    end
+
+    it "loads the model using a proc" do
+      model = Model.new
+      allow(Model).to receive(:find).with("123") { model }
+
+      resource = CanCan::ControllerResource.new(controller, :class => proc { Model })
+      resource.load_resource
+      expect(controller.instance_variable_get(:@model)).to eq(model)
+    end
+
     it "authorizes based on resource name if class is false" do
       allow(controller).to receive(:authorize!).with(:show, :model) { raise CanCan::AccessDenied }
       resource = CanCan::ControllerResource.new(controller, :class => false)


### PR DESCRIPTION
I have a particular case, where the `:class` option for `load_and_authorize_resource` depends on various conditions, evaluated in the context of the controller instance.

I suggest to support symbol and/or proc for setting this options : 

```
class FooController < ApplicationController
  load_and_authorize_resource :foo, class: :model

  def model
    whatever? ? Foo1 : Foo2
  end
end
```

```
class FooController < ApplicationController
  load_and_authorize_resource :foo, class: proc { whatever? ? Foo1 : Foo2 }
end
```

What do you think ?

NOTE: This PR is a duplicate of #239, sorry!
