### PR TITLE
RSpec 3.2 compatibility

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,12 +1,9 @@
 Develop
 
-1.12.1 (September 24th, 2015)
-
-* Removed deprecation warnings for RSpec 3.2
-
 1.12.0 (June 28th, 2015)
 
 * Add a permissions method to Ability (devaroop)
+* Removed deprecation warnings for RSpec 3.2 (NekoNova)
 
 1.11.0 (June 15th, 2015)
 

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,9 @@
 Develop
 
+1.12.1 (September 24th, 2015)
+
+* Removed deprecation warnings for RSpec 3.2
+
 1.12.0 (June 28th, 2015)
 
 * Add a permissions method to Ability (devaroop)

--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '~> 1.3'
   s.add_development_dependency 'rake', '~> 10.1.1'
-  s.add_development_dependency 'rspec', '~> 3.0.0'
+  s.add_development_dependency 'rspec', '~> 3.2.0'
   s.add_development_dependency 'appraisal', '>= 2.0.0'
 end

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -15,6 +15,9 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
   # Check that RSpec is < 2.99
   if !respond_to?(:failure_message) && respond_to?(:failure_message_for_should)
     alias :failure_message :failure_message_for_should
+  end
+
+  if !respond_to?(:failure_message_when_negated) && respond_to?(:failure_message_for_should_not)
     alias :failure_message_when_negated :failure_message_for_should_not
   end
 

--- a/lib/cancan/version.rb
+++ b/lib/cancan/version.rb
@@ -1,3 +1,3 @@
 module CanCan
-  VERSION = "1.12.1"
+  VERSION = "1.12.0"
 end

--- a/lib/cancan/version.rb
+++ b/lib/cancan/version.rb
@@ -1,3 +1,3 @@
 module CanCan
-  VERSION = "1.12.0"
+  VERSION = "1.12.1"
 end


### PR DESCRIPTION
I've rewritten the way the methods are aliased for RSpec. This effectively removed all deprecation warnings from our Jenkins test-suite.

I'm not sure whether I've changed the changelog correctly, feel free to change if needed.