### PR TITLE
Fix #merge with empty Ability

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -285,7 +285,9 @@ module CanCan
 
     # Must be protected as an ability can merge with other abilities.
     # This means that an ability must expose their rules with another ability.
-    attr_reader :rules
+    def rules
+      @rules ||= []
+    end
 
     private
 
@@ -338,9 +340,8 @@ module CanCan
     end
 
     def add_rule(rule)
-      @rules ||= []
-      @rules << rule
-      add_rule_to_index(rule, @rules.size - 1)
+      rules << rule
+      add_rule_to_index(rule, rules.size - 1)
     end
 
     def add_rule_to_index(rule, position)

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -510,5 +510,12 @@ describe CanCan::Ability do
       expect(@ability.can?(:use, :search)).to be(true)
       expect(@ability.send(:rules).size).to eq(2)
     end
+
+    it "can add an empty ability" do
+      (another_ability = double).extend(CanCan::Ability)
+
+      @ability.merge(another_ability)
+      expect(@ability.send(:rules).size).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Using `merge` with an empty ability caused an error due to `rules.each` being `nil.each`.

This moves the default value of `@rules` to the `#rules` method.