### PR TITLE
Execute SQL when evaluating a conditional rule on an AR scope

### DIFF
--- a/lib/cancan/model_adapters/abstract_adapter.rb
+++ b/lib/cancan/model_adapters/abstract_adapter.rb
@@ -42,6 +42,17 @@ module CanCan
         raise NotImplemented, "This model adapter does not support matching on a specific condition."
       end
 
+      # Used to determine if this model adapter can provide optimized association matching.
+      # If this returns true then matches_association? will be called. See Rule#hash_condition_match?
+      def self.override_association_matching?(subject, conditions)
+        false
+      end
+
+      # Override if override_association_matching? returns true
+      def self.matches_association?(subject, conditions)
+        raise NotImplemented, "This model adapter does not support matching on an association."
+      end
+
       def initialize(model_class, rules)
         @model_class = model_class
         @rules = rules

--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -6,6 +6,37 @@ module CanCan
         model_class <= ActiveRecord::Base
       end
 
+      def self.override_association_matching?(subject, conditions)
+        subject.kind_of?(ActiveRecord::Relation) && !subject.loaded?
+      end
+
+      def self.matches_association?(subject, conditions)
+        where_conditions = association_conditions_for(subject.proxy_association.reflection, conditions)
+        subject.where(where_conditions).any?
+      end
+
+      def self.association_conditions_for(reflection, conditions)
+        {}.tap do |result|
+          target = reflection.klass
+          conditions.each_pair do |key, value|
+            key, value = association_condition_for(target, key, value)
+            result[key] = value
+          end
+        end
+      end
+
+      def self.association_condition_for(target, key, value)
+        string_key = key.to_s
+        if ActiveRecord::VERSION::MINOR >= 1 && target.defined_enums.include?(string_key)
+          enum = target.send(string_key.pluralize)
+          [key, value.is_a?(Enumerable) ? value.map { |v| enum[v] } : enum[value]]
+        elsif value.is_a?(Hash)
+          [target.table_name.to_sym, association_conditions_for(target.reflect_on_association(key), value)]
+        else
+          [key, value]
+        end
+      end
+
       private
 
       # As of rails 4, `includes()` no longer causes active record to

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -114,7 +114,7 @@ module CanCan
         if adapter.override_condition_matching?(subject, name, value)
           adapter.matches_condition?(subject, name, value)
         else
-          condition_match?(subject.send(name), value)
+          condition_match?(adapter, subject.send(name), value)
         end
       end
     end
@@ -136,18 +136,20 @@ module CanCan
       CanCan::ModelAdapters::AbstractAdapter.adapter_class(subject_class?(subject) ? subject : subject.class)
     end
 
-    def condition_match?(attribute, value)
+    def condition_match?(adapter, attribute, value)
       case value
-      when Hash       then hash_condition_match?(attribute, value)
+      when Hash       then hash_condition_match?(adapter, attribute, value)
       when String     then attribute == value
       when Enumerable then value.include?(attribute)
       else attribute == value
       end
     end
 
-    def hash_condition_match?(attribute, value)
-      if attribute.kind_of?(Array) || (defined?(ActiveRecord) && attribute.kind_of?(ActiveRecord::Relation))
-        attribute.any? { |element| matches_conditions_hash?(element, value) }
+    def hash_condition_match?(adapter, attribute, value)
+      if adapter.override_association_matching?(attribute, value)
+        adapter.matches_association?(attribute, value)
+      elsif attribute.kind_of?(Array) || attribute.respond_to?(:to_a)
+        attribute.to_a.any? { |element| matches_conditions_hash?(element, value) }
       else
         !attribute.nil? && matches_conditions_hash?(attribute, value)
       end

--- a/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
@@ -148,6 +148,15 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
 
           expect(Parent.accessible_by(@ability)).to eq([parent])
         end
+
+        it "allows querying hash conditions via the relation", focus: true do
+          @ability.can :read, Parent, :children => {:parent_id => 2}
+
+          parent = Parent.create!
+          expect(parent.children).to receive_message_chain(:where, :any?).and_return(true)
+
+          @ability.can?(:read, parent)
+        end
       end
     end
   end


### PR DESCRIPTION
When we are evaluating arguments within the context of an AR scope, execute the SQL instead of loading all rows to memory.

Typically we would be using this on records where the association is not loaded to memory because there are too many. Cancancan will currently load all the association's rows then evaluate against the conditions.

If the old behaviour of checking conditions directly is desired, then the collection can be eager loaded instead. Loaded collections will not execute another SQL query.

This only affects AR4, since AR3 does not allow us to obtain an association proxy.

Comments welcome.
