### PR TITLE
Optimize performance of `cancan_resource_class`

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -280,7 +280,7 @@ module CanCan
       end
 
       def cancan_resource_class
-        if ancestors.map(&:to_s).include? "InheritedResources::Actions"
+        if defined?(InheritedResources) && ancestors.map(&:to_s).include?("InheritedResources::Actions")
           InheritedResource
         else
           ControllerResource


### PR DESCRIPTION
No need to stringify all ancestors if InheritedResources is not even used in the project.
