### PR TITLE
Gemspec should not require ruby version > 2.0.0 for JRuby

### DIFF
--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split($/).map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 2.0.0" unless RUBY_PLATFORM == 'java'
 
   s.add_development_dependency 'bundler', '~> 1.3'
   s.add_development_dependency 'rake', '~> 10.1.1'


### PR DESCRIPTION
The Travis build tests against Jruby 1.7.20, but you can't install the gem with that version of the interpreter.

Assuming this change is accepted, I'd also like this commit to be cherry-picked to the 1.x branch and a new release pushed to rubygems.
