### PR TITLE
Fix attempt to #constantize a symbolic name

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -262,9 +262,7 @@ module CanCan
     end
 
     def namespaced_name
-      [namespace, name.camelize].flatten.map(&:camelize).join('::').singularize.constantize
-    rescue NameError
-      name
+      ([namespace, name] * '/').singularize.camelize.safe_constantize || name
     end
 
     def name_from_controller

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -501,6 +501,17 @@ describe CanCan::ControllerResource do
     end
   end
 
+  context 'when @name passed as symbol' do
+    it 'returns namespaced #resource_class' do
+      module Admin; end
+      class Admin::Dashboard; end;
+      params.merge!(:controller => "admin/dashboard")
+      resource = CanCan::ControllerResource.new(controller, :dashboard)
+
+      expect(resource.send(:resource_class)).to eq Admin::Dashboard
+    end
+  end
+
   it "calls the santitizer when the parameter hash matches our object" do
     params.merge!(:action => 'create', :model => { :name => 'test' })
     allow(controller).to receive(:create_params).and_return({})


### PR DESCRIPTION
Related with #146, 6c497b8.

I run into this problem when implementing a successive version of a resource.
I was using something like next in controller:

```ruby
class V2::InvoiceController < V2::BaseController
  load_and_authorize_resource :invoice
end
```

Pretty similar to what docs suggests. But regardless of existing logic that try to compose namespaced resource. It fails due to passing a name of the resource as `:invoice` symbols. And rescuing with a not namespaced resource.

```ruby
def namespaced_name
  [namespace, name.camelize].flatten.map(&:camelize).join('::').singularize.constantize
rescue NameError
  name
end
```

So instead of `V2::Invoice` it returns an `Invoice`.

This PR is about fixing that problem and get rid of `rescue` from almost base error class.