### PR TITLE
Use `cover?` for ranges

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -140,6 +140,7 @@ module CanCan
       case value
       when Hash       then hash_condition_match?(attribute, value)
       when String     then attribute == value
+      when Range      then value.cover?(attribute)
       when Enumerable then value.include?(attribute)
       else attribute == value
       end

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -294,6 +294,13 @@ describe CanCan::Ability do
     expect(@ability.can?(:read, 4..40)).to be(false)
   end
 
+  it "allows a range of time in conditions hash" do
+    @ability.can :read, Range, :begin => 1.day.from_now..3.days.from_now
+    expect(@ability.can?(:read, 1.day.from_now..10.days.from_now)).to be(true)
+    expect(@ability.can?(:read, 2.days.from_now..20.days.from_now)).to be(true)
+    expect(@ability.can?(:read, 4.days.from_now..40.days.from_now)).to be(false)
+  end
+
   it "allows nested hashes in conditions hash" do
     @ability.can :read, Range, :begin => { :to_i => 5 }
     expect(@ability.can?(:read, 5..7)).to be(true)

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -380,5 +380,26 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
         expect(Namespace::TableX.accessible_by(ability)).to eq([table_x])
       end
     end
+
+    context 'when conditions are non iterable ranges' do
+      before :each do
+        ActiveRecord::Schema.define do
+          create_table( :courses ) do |t|
+            t.datetime :start_at
+          end
+        end
+
+        class Course < ActiveRecord::Base
+        end
+      end
+
+      it 'fetches only the valid records' do
+        @ability.can :read, Course, :start_at => 1.day.ago..1.day.from_now
+        Course.create!(:start_at => 10.days.ago)
+        valid_course = Course.create!(:start_at => Time.now)
+
+        expect(Course.accessible_by(@ability)).to eq([valid_course])
+      end
+    end
   end
 end


### PR DESCRIPTION
Both `Time` and `ActiveSupport::TimeWithZone` are not iterable:

```
time_range = Time.now..1.day.from_now
time_range.include?(Time.now)

=> TypeError: can't iterate from ActiveSupport::TimeWithZone
```

We should use `cover?` in this case.

Any comments ?