### PR TITLE
AC::Parameters no longer inherits from HWIA

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -12,7 +12,7 @@ module CanCan
       #   end
       #
       def load_and_authorize_resource(*args)
-        cancan_resource_class.add_before_filter(self, :load_and_authorize_resource, *args)
+        cancan_resource_class.add_before_action(self, :load_and_authorize_resource, *args)
       end
 
       # Sets up a before filter which loads the model resource into an instance variable.
@@ -32,10 +32,10 @@ module CanCan
       #   end
       #
       # A resource is not loaded if the instance variable is already set. This makes it easy to override
-      # the behavior through a before_filter on certain actions.
+      # the behavior through a before_action on certain actions.
       #
       #   class BooksController < ApplicationController
-      #     before_filter :find_book_by_permalink, :only => :show
+      #     before_action :find_book_by_permalink, :only => :show
       #     load_resource
       #
       #     private
@@ -115,10 +115,10 @@ module CanCan
       #     load_resource :new => :build
       #
       # [:+prepend+]
-      #   Passing +true+ will use prepend_before_filter instead of a normal before_filter.
+      #   Passing +true+ will use prepend_before_action instead of a normal before_action.
       #
       def load_resource(*args)
-        cancan_resource_class.add_before_filter(self, :load_resource, *args)
+        cancan_resource_class.add_before_action(self, :load_resource, *args)
       end
 
       # Sets up a before filter which authorizes the resource using the instance variable.
@@ -174,10 +174,10 @@ module CanCan
       #   Authorize conditions on this parent resource when instance isn't available.
       #
       # [:+prepend+]
-      #   Passing +true+ will use prepend_before_filter instead of a normal before_filter.
+      #   Passing +true+ will use prepend_before_action instead of a normal before_action.
       #
       def authorize_resource(*args)
-        cancan_resource_class.add_before_filter(self, :authorize_resource, *args)
+        cancan_resource_class.add_before_action(self, :authorize_resource, *args)
       end
 
       # Skip both the loading and authorization behavior of CanCan for this given controller. This is primarily
@@ -254,7 +254,7 @@ module CanCan
       #     check_authorization :unless => :devise_controller?
       #
       def check_authorization(options = {})
-        self.after_filter(options.slice(:only, :except)) do |controller|
+        self.after_action(options.slice(:only, :except)) do |controller|
           next if controller.instance_variable_defined?(:@_authorized)
           next if options[:if] && !controller.send(options[:if])
           next if options[:unless] && controller.send(options[:unless])
@@ -268,9 +268,9 @@ module CanCan
       #     skip_authorization_check :only => :index
       #   end
       #
-      # Any arguments are passed to the +before_filter+ it triggers.
+      # Any arguments are passed to the +before_action+ it triggers.
       def skip_authorization_check(*args)
-        self.before_filter(*args) do |controller|
+        self.before_action(*args) do |controller|
           controller.instance_variable_set(:@_authorized, true)
         end
       end

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -2,11 +2,11 @@ module CanCan
   # Handle the load and authorization controller logic so we don't clutter up all controllers with non-interface methods.
   # This class is used internally, so you do not need to call methods directly on it.
   class ControllerResource # :nodoc:
-    def self.add_before_filter(controller_class, method, *args)
+    def self.add_before_action(controller_class, method, *args)
       options = args.extract_options!
       resource_name = args.first
-      before_filter_method = options.delete(:prepend) ? :prepend_before_filter : :before_filter
-      controller_class.send(before_filter_method, options.slice(:only, :except, :if, :unless)) do |controller|
+      before_action_method = options.delete(:prepend) ? :prepend_before_action : :before_action
+      controller_class.send(before_action_method, options.slice(:only, :except, :if, :unless)) do |controller|
         controller.class.cancan_resource_class.new(controller, resource_name, options.except(:only, :except, :if, :unless)).send(method)
       end
     end

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -91,7 +91,7 @@ module CanCan
 
     def initial_attributes
       current_ability.attributes_for(@params[:action].to_sym, resource_class).delete_if do |key, value|
-        resource_params && resource_params.include?(key)
+        resource_params && resource_params.has_key?(key)
       end
     end
 

--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -33,44 +33,44 @@ describe CanCan::ControllerAdditions do
   it "load_and_authorize_resource setups a before filter which passes call to ControllerResource" do
     expect(cancan_resource_class = double).to receive(:load_and_authorize_resource)
     allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, :foo => :bar) {cancan_resource_class }
-    expect(@controller_class).to receive(:before_filter).with({}) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:before_action).with({}) { |options, &block| block.call(@controller) }
     @controller_class.load_and_authorize_resource :foo => :bar
   end
 
   it "load_and_authorize_resource properly passes first argument as the resource name" do
     expect(cancan_resource_class = double).to receive(:load_and_authorize_resource)
     allow(CanCan::ControllerResource).to receive(:new).with(@controller, :project, :foo => :bar) {cancan_resource_class}
-    expect(@controller_class).to receive(:before_filter).with({}) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:before_action).with({}) { |options, &block| block.call(@controller) }
     @controller_class.load_and_authorize_resource :project, :foo => :bar
   end
 
   it "load_and_authorize_resource with :prepend prepends the before filter" do
-    expect(@controller_class).to receive(:prepend_before_filter).with({})
+    expect(@controller_class).to receive(:prepend_before_action).with({})
     @controller_class.load_and_authorize_resource :foo => :bar, :prepend => true
   end
 
   it "authorize_resource setups a before filter which passes call to ControllerResource" do
     expect(cancan_resource_class = double).to receive(:authorize_resource)
     allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, :foo => :bar) {cancan_resource_class}
-    expect(@controller_class).to receive(:before_filter).with(:except => :show, :if => true) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:before_action).with(:except => :show, :if => true) { |options, &block| block.call(@controller) }
     @controller_class.authorize_resource :foo => :bar, :except => :show, :if => true
   end
 
   it "load_resource setups a before filter which passes call to ControllerResource" do
     expect(cancan_resource_class = double).to receive(:load_resource)
     allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, :foo => :bar) {cancan_resource_class}
-    expect(@controller_class).to receive(:before_filter).with(:only => [:show, :index], :unless => false) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:before_action).with(:only => [:show, :index], :unless => false) { |options, &block| block.call(@controller) }
     @controller_class.load_resource :foo => :bar, :only => [:show, :index], :unless => false
   end
 
   it "skip_authorization_check setups a before filter which sets @_authorized to true" do
-    expect(@controller_class).to receive(:before_filter).with(:filter_options) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:before_action).with(:filter_options) { |options, &block| block.call(@controller) }
     @controller_class.skip_authorization_check(:filter_options)
     expect(@controller.instance_variable_get(:@_authorized)).to be(true)
   end
 
   it "check_authorization triggers AuthorizationNotPerformed in after filter" do
-    expect(@controller_class).to receive(:after_filter).with(:only => [:test]) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:after_action).with(:only => [:test]) { |options, &block| block.call(@controller) }
     expect {
       @controller_class.check_authorization(:only => [:test])
     }.to raise_error(CanCan::AuthorizationNotPerformed)
@@ -78,7 +78,7 @@ describe CanCan::ControllerAdditions do
 
   it "check_authorization does not trigger AuthorizationNotPerformed when :if is false" do
     allow(@controller).to receive(:check_auth?) { false }
-    allow(@controller_class).to receive(:after_filter).with({}) { |options, &block| block.call(@controller) }
+    allow(@controller_class).to receive(:after_action).with({}) { |options, &block| block.call(@controller) }
     expect {
       @controller_class.check_authorization(:if => :check_auth?)
     }.not_to raise_error
@@ -86,7 +86,7 @@ describe CanCan::ControllerAdditions do
 
   it "check_authorization does not trigger AuthorizationNotPerformed when :unless is true" do
     allow(@controller).to receive(:engine_controller?) { true }
-    expect(@controller_class).to receive(:after_filter).with({}) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:after_action).with({}) { |options, &block| block.call(@controller) }
     expect {
       @controller_class.check_authorization(:unless => :engine_controller?)
     }.not_to raise_error
@@ -94,7 +94,7 @@ describe CanCan::ControllerAdditions do
 
   it "check_authorization does not raise error when @_authorized is set" do
     @controller.instance_variable_set(:@_authorized, true)
-    expect(@controller_class).to receive(:after_filter).with(:only => [:test]) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(:after_action).with(:only => [:test]) { |options, &block| block.call(@controller) }
     expect {
       @controller_class.check_authorization(:only => [:test])
     }.not_to raise_error


### PR DESCRIPTION
ActionController::Parameters no longer inherits from HashWithIndirectAccess and so does not respond to :include? It does delegate the has_key? method which does the same job.