### PR TITLE
Build the join and used the assigned table name for building the conditions hash

### DIFF
--- a/lib/cancan/model_adapters/active_record_3_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_3_adapter.rb
@@ -6,6 +6,29 @@ module CanCan
         model_class <= ActiveRecord::Base
       end
 
+      def tableized_conditions(conditions, model_class = @model_class)
+        return conditions unless conditions.kind_of? Hash
+        conditions.inject({}) do |result_hash, (name, value)|
+          if value.kind_of? Hash
+            value = value.dup
+            association_class = model_class.reflect_on_association(name).klass.name.constantize
+            nested = value.inject({}) do |nested,(k,v)|
+              if v.kind_of? Hash
+                value.delete(k)
+                nested[k] = v
+              else
+                result_hash[model_class.reflect_on_association(name).table_name.to_sym] = value
+              end
+              nested
+            end
+            result_hash.merge!(tableized_conditions(nested,association_class))
+          else
+            result_hash[name] = value
+          end
+          result_hash
+        end
+      end
+
       private
 
       def build_relation(*where_conditions)

--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -6,7 +6,59 @@ module CanCan
         model_class <= ActiveRecord::Base
       end
 
+      def tableized_conditions(conditions, model_class = @model_class,
+                               current_nesting = [], current_scope = model_class.all)
+        return conditions unless conditions.kind_of? Hash
+        conditions.inject({}) do |result_hash, (name, value)|
+          if value.kind_of? Hash
+            value = value.dup
+            new_nesting = current_nesting + [name]
+            joins_hash = nesting_to_joins_hash(new_nesting)
+            current_scope = current_scope.joins(joins_hash)
+            association_class = model_class.reflect_on_association(name).klass.name.constantize
+            table_name = table_name_for_scope(current_scope).to_sym
+            nested = value.inject({}) do |nested,(k,v)|
+              if v.kind_of? Hash
+                value.delete(k)
+                nested[k] = v
+              else
+                result_hash[table_name] = value
+              end
+              nested
+            end
+            result_hash.merge!(tableized_conditions(nested, association_class,
+                                                    new_nesting, current_scope))
+          else
+            result_hash[name] = value
+          end
+          result_hash
+        end
+      end
+
       private
+
+      def table_name_for_scope(current_scope)
+        current_table = current_scope.arel.source.right.last.left
+
+        case current_table
+        when Arel::Table
+          current_table.name
+        when Arel::Nodes::TableAlias
+          current_table.right
+        else
+          fail
+        end
+      end
+
+      def nesting_to_joins_hash(nesting)
+        nesting.reverse.reduce(nil) do |a, e|
+          if a.nil?
+            e
+          else
+            { e => a }
+          end
+        end
+      end
 
       # As of rails 4, `includes()` no longer causes active record to
       # look inside the where clause to decide to outer join tables

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -27,58 +27,6 @@ module CanCan
         end
       end
 
-      def table_name_for_scope(current_scope)
-        current_table = current_scope.arel.source.right.last.left
-
-        case current_table
-        when Arel::Table
-          current_table.name
-        when Arel::Nodes::TableAlias
-          current_table.right
-        else
-          fail
-        end
-      end
-
-      def nesting_to_joins_hash(nesting)
-        nesting.reverse.reduce(nil) do |a, e|
-          if a.nil?
-            e
-          else
-            { e => a }
-          end
-        end
-      end
-
-      def tableized_conditions(conditions, model_class = @model_class,
-                               current_nesting = [], current_scope = model_class.all)
-        return conditions unless conditions.kind_of? Hash
-        conditions.inject({}) do |result_hash, (name, value)|
-          if value.kind_of? Hash
-            value = value.dup
-            new_nesting = current_nesting + [name]
-            joins_hash = nesting_to_joins_hash(new_nesting)
-            current_scope = current_scope.joins(joins_hash)
-            association_class = model_class.reflect_on_association(name).klass.name.constantize
-            table_name = table_name_for_scope(current_scope).to_sym
-            nested = value.inject({}) do |nested,(k,v)|
-              if v.kind_of? Hash
-                value.delete(k)
-                nested[k] = v
-              else
-                result_hash[table_name] = value
-              end
-              nested
-            end
-            result_hash.merge!(tableized_conditions(nested, association_class,
-                                                    new_nesting, current_scope))
-          else
-            result_hash[name] = value
-          end
-          result_hash
-        end
-      end
-
       # Returns the associations used in conditions for the :joins option of a search.
       # See ModelAdditions#accessible_by
       def joins

--- a/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
@@ -20,6 +20,7 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
 
         class Parent < ActiveRecord::Base
           has_many :children, lambda { order(:id => :desc) }
+          has_many :other_parents, through: :children
         end
 
         class Child < ActiveRecord::Base
@@ -55,6 +56,17 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
         child1 = Child.create!(parent: parent2, other_parent: parent1)
 
         expect(Parent.accessible_by(@ability)).to contain_exactly(parent2)
+      end
+
+      it "allows using accessible_by on a chained scope" do
+        parent1 = Parent.create!
+        parent2 = Parent.create!
+        parent3 = Parent.create!
+        child1 = Child.create!(:parent => parent1, :other_parent => parent2)
+        child2 = Child.create!(:parent => parent2, :other_parent => parent3)
+        @ability.can :read, Parent, :other_parents => { :id => parent3.id }
+
+        expect(parent1.other_parents.accessible_by(@ability)).to contain_exactly(parent2)
       end
 
       if ActiveRecord::VERSION::MINOR >= 1

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -227,6 +227,22 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
       expect { Comment.accessible_by(@ability) }.to_not raise_error
     end
 
+    it "should support repeated tables in deeply nested conditions" do
+      @ability.can :read, Article, :mentioned_users => {
+        :articles => {
+          :published => true
+        }
+      }
+
+      user1 = User.create!
+      user2 = User.create!
+      article1 = Article.create!(user: user1)
+      article1.mentions.create!(user: user2)
+      article2 = Article.create!(user: user2, published: true)
+
+      expect(Article.accessible_by(@ability)).to contain_exactly(article1)
+    end
+
     it "does not allow to check ability on object against SQL conditions without block" do
       @ability.can :read, Article, ["secret=?", true]
       expect(lambda { @ability.can? :read, Article.new }).to raise_error(CanCan::Error)

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -227,22 +227,6 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
       expect { Comment.accessible_by(@ability) }.to_not raise_error
     end
 
-    it "should support repeated tables in deeply nested conditions" do
-      @ability.can :read, Article, :mentioned_users => {
-        :articles => {
-          :published => true
-        }
-      }
-
-      user1 = User.create!
-      user2 = User.create!
-      article1 = Article.create!(user: user1)
-      article1.mentions.create!(user: user2)
-      article2 = Article.create!(user: user2, published: true)
-
-      expect(Article.accessible_by(@ability)).to contain_exactly(article1)
-    end
-
     it "does not allow to check ability on object against SQL conditions without block" do
       @ability.can :read, Article, ["secret=?", true]
       expect(lambda { @ability.can? :read, Article.new }).to raise_error(CanCan::Error)


### PR DESCRIPTION
This fixes #284.

What this does is, instead of assuming that tables always get the same SQL table name, we actually perform the join to figure out what alias the table is given, and use that to specify the conditions.

cc @kxmbrian
