### PR TITLE
Avoid unnecessary checks [develop]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
-  - jruby
+  - jruby-9.0.5.0
 gemfile:
   - gemfiles/activerecord_3.2.gemfile
   - gemfiles/activerecord_4.0.gemfile

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -52,6 +52,22 @@ describe CanCan::Ability do
     expect(@ability.can?(:read, 6)).to be(true)
   end
 
+  it "performs can(_, :all) before other checks when can(_, :all) is defined before" do
+    @ability.can :manage, :all
+    @ability.can :edit, String do |_string|
+      fail 'Performed a check for :edit before the check for :all'
+    end
+    expect { @ability.can? :edit, 'a' }.to_not raise_exception
+  end
+
+  it "performs can(_, :all) before other checks when can(_, :all) is defined after" do
+    @ability.can :edit, String do |_string|
+      fail 'Performed a check for :edit before the check for :all'
+    end
+    @ability.can :manage, :all
+    expect { @ability.can? :edit, 'a' }.to_not raise_exception
+  end
+
   it "does not pass class with object if :all objects are accepted" do
     @ability.can :preview, :all do |object|
       expect(object).to eq(123)


### PR DESCRIPTION
* Evaluate `:all` rules before any other rules in the consecutive `base_behavior == true` rules.
* Abort evaluation on the first matching subject.
* Use JRuby 9 on Travis (for `Enumerable#lazy`).

Also backported to 1.13.x in #315.