### PR TITLE
Controller asks current_ability if it has been authorized

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -222,7 +222,7 @@ module CanCan
 
     # Returns whether this ability has had authorize! called
     def authorize_called?
-      @_authorized
+      @_authorized == true
     end
 
     def unauthorized_message(action, subject)

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -207,6 +207,8 @@ module CanCan
 
     # See ControllerAdditions#authorize! for documentation.
     def authorize!(action, subject, *args)
+      @_authorized = true
+
       message = nil
       if args.last.kind_of?(Hash) && args.last.has_key?(:message)
         message = args.pop[:message]
@@ -216,6 +218,11 @@ module CanCan
         raise AccessDenied.new(message, action, subject)
       end
       subject
+    end
+
+    # Returns whether this ability has had authorize! called
+    def authorize_called?
+      @_authorized
     end
 
     def unauthorized_message(action, subject)

--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -255,7 +255,7 @@ module CanCan
       #
       def check_authorization(options = {})
         self.after_filter(options.slice(:only, :except)) do |controller|
-          next if controller.instance_variable_defined?(:@_authorized)
+          next if controller.current_ability && controller.current_ability.authorize_called?
           next if options[:if] && !controller.send(options[:if])
           next if options[:unless] && controller.send(options[:unless])
           raise AuthorizationNotPerformed, "This action failed the check_authorization because it does not authorize_resource. Add skip_authorization_check to bypass this check."
@@ -334,7 +334,6 @@ module CanCan
     # See the load_and_authorize_resource method to automatically add the authorize! behavior
     # to the default RESTful actions.
     def authorize!(*args)
-      @_authorized = true
       current_ability.authorize!(*args)
     end
 

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -480,6 +480,15 @@ describe CanCan::Ability do
     }.to raise_error(CanCan::Error, "You are not able to supply a block with a hash of conditions in read Array ability. Use either one.")
   end
 
+  it "calling #authorize! changes #authorize_called? to true" do
+    allow(@ability).to receive(:cannot?).with(:foo, :bar).and_return(false)
+    expect{
+      @ability.authorize! :foo, :bar
+    }.to change{
+      @ability.authorize_called?
+    }.from(false).to(true)
+  end
+
   describe "unauthorized message" do
     after(:each) do
       I18n.backend = nil

--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -17,7 +17,7 @@ describe CanCan::ControllerAdditions do
   it "authorize! assigns @_authorized instance variable and pass args to current ability" do
     allow(@controller.current_ability).to receive(:cannot?).with(:foo, :bar).and_return(false)
     @controller.authorize!(:foo, :bar)
-    expect(@controller.current_ability.instance_variable_get(:@_authorized)).to be(true)
+    expect(@controller.current_ability.authorize_called?).to be(true)
   end
 
   it "has a current_ability method which generates an ability for the current user" do

--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -15,9 +15,15 @@ describe CanCan::ControllerAdditions do
   end
 
   it "authorize! assigns @_authorized instance variable and pass args to current ability" do
-    allow(@controller.current_ability).to receive(:authorize!).with(:foo, :bar)
+    allow(@controller.current_ability).to receive(:cannot?).with(:foo, :bar).and_return(false)
     @controller.authorize!(:foo, :bar)
-    expect(@controller.instance_variable_get(:@_authorized)).to be(true)
+    expect(@controller.current_ability.instance_variable_get(:@_authorized)).to be(true)
+  end
+
+  it "authorize! results in current ability#authorize_called? returning true" do
+    allow(@controller.current_ability).to receive(:cannot?).with(:foo, :bar).and_return(false)
+    @controller.authorize!(:foo, :bar)
+    expect(@controller.current_ability.authorize_called?).to be(true)
   end
 
   it "has a current_ability method which generates an ability for the current user" do
@@ -92,8 +98,8 @@ describe CanCan::ControllerAdditions do
     }.not_to raise_error
   end
 
-  it "check_authorization does not raise error when @_authorized is set" do
-    @controller.instance_variable_set(:@_authorized, true)
+  it "check_authorization does not raise error when @_authorized is set on current_ability" do
+    @controller.current_ability.instance_variable_set(:@_authorized, true)
     expect(@controller_class).to receive(:after_filter).with(:only => [:test]) { |options, &block| block.call(@controller) }
     expect {
       @controller_class.check_authorization(:only => [:test])

--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -20,12 +20,6 @@ describe CanCan::ControllerAdditions do
     expect(@controller.current_ability.instance_variable_get(:@_authorized)).to be(true)
   end
 
-  it "authorize! results in current ability#authorize_called? returning true" do
-    allow(@controller.current_ability).to receive(:cannot?).with(:foo, :bar).and_return(false)
-    @controller.authorize!(:foo, :bar)
-    expect(@controller.current_ability.authorize_called?).to be(true)
-  end
-
   it "has a current_ability method which generates an ability for the current user" do
     expect(@controller.current_ability).to be_kind_of(Ability)
   end


### PR DESCRIPTION
In our company we want to move the `authorize!` calls out of our controllers. Unfortunately this currently means we would have to give up `check_authorization`, since this currently relies on the instance var @_authorized being set on the controller.

This PR changes that so the controller asks the current_ability if it has had `authorize!` called. Now we can pass the current ability into other objects, and still use `check_authorization` in our controllers.

I did not know what to add to the CHANGELOG. Any help is appreciated.
