### PR TITLE
Changed includes to joins so .select() can still be used

### DIFF
--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -14,7 +14,7 @@ module CanCan
       # in addition to `includes()` to force the outer join.
       def build_relation(*where_conditions)
         relation = @model_class.where(*where_conditions)
-        relation = relation.includes(joins).references(joins) if joins.present?
+        relation = relation.joins(joins).references(joins) if joins.present?
         relation
       end
 


### PR DESCRIPTION
I noticed that .select() cannot be used with a cancan loaded query, as .includes() actually renames the columns. If .includes() is changed to .joins(), you get the same result with the ability to use custom selects.