### PR TITLE
Fix issue with ActiveRecord initialization

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -2,6 +2,8 @@ Develop
 
 Unreleased
 
+* Fix bug in ActiveRecord configuration (alexsanford)
+
 1.15.0 (June 13th, 2016)
 
 * Add support for Rails 5 (craig1410)

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -143,6 +143,8 @@ module CanCan
   end
 end
 
-ActiveRecord::Base.class_eval do
-  include CanCan::ModelAdditions
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.class_eval do
+    include CanCan::ModelAdditions
+  end
 end


### PR DESCRIPTION
Fixes #342

This patch ensures that the model adapter code requiring ActiveRecord is not run until after ActiveRecord has been loaded (explanation [here](https://github.com/CanCanCommunity/cancancan/issues/342#issuecomment-239687074)).

It's not clear to me how I would write a spec for this. I would love to be able to check the actual config values that caused the problem in the original issue. But that would probably involve running a dummy Rails app, which seems like overkill for such a small fix. Thoughts?