### PR TITLE
Update spec readme with the mongodb information

### DIFF
--- a/spec/README.rdoc
+++ b/spec/README.rdoc
@@ -10,6 +10,11 @@ Then run the appraisal command to install all the necessary test sets:
 
   appraisal install
 
+Install the mongodb
+
+  brew install mongodb
+  brew services start mongodb
+
 You can then run all test sets:
 
   appraisal rake


### PR DESCRIPTION
I ran into few issues while getting the specs pass in local, mainly about the missing mongoid information. I updated the Spec Readme(https://github.com/shivhg/cancancan/blob/develop/spec/README.rdoc).
