### PR TITLE
Make accessible_by support multiple rules referencing the same table with different rules

### DIFF
--- a/lib/cancan/model_adapters/active_record_3_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_3_adapter.rb
@@ -5,12 +5,6 @@ module CanCan
       def self.for_class?(model_class)
         model_class <= ActiveRecord::Base
       end
-
-      private
-
-      def build_relation(*where_conditions)
-        @model_class.where(*where_conditions).includes(joins)
-      end
     end
   end
 end

--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -8,16 +8,6 @@ module CanCan
 
       private
 
-      # As of rails 4, `includes()` no longer causes active record to
-      # look inside the where clause to decide to outer join tables
-      # you're using in the where. Instead, `references()` is required
-      # in addition to `includes()` to force the outer join.
-      def build_relation(*where_conditions)
-        relation = @model_class.where(*where_conditions)
-        relation = relation.includes(joins).references(joins) if joins.present?
-        relation
-      end
-
       def self.override_condition_matching?(subject, name, value)
         # ActiveRecord introduced enums in version 4.1.
         (ActiveRecord::VERSION::MAJOR > 4 || ActiveRecord::VERSION::MINOR >= 1) &&
@@ -33,35 +23,6 @@ module CanCan
         value.is_a?(Enumerable) ? 
           (value.include? attribute) :
           attribute == value
-      end
-
-      # Rails 4.2 deprecates `sanitize_sql_hash_for_conditions`
-      def sanitize_sql(conditions)
-        if ActiveRecord::VERSION::MAJOR > 4 && Hash === conditions
-          table = @model_class.send(:arel_table)
-          table_metadata = ActiveRecord::TableMetadata.new(@model_class, table)
-          predicate_builder = ActiveRecord::PredicateBuilder.new(table_metadata)
-
-          conditions = predicate_builder.resolve_column_aliases(conditions)
-          conditions = @model_class.send(:expand_hash_conditions_for_aggregates, conditions)
-
-          conditions.stringify_keys!
-
-          predicate_builder.build_from_hash(conditions).map { |b|
-            @model_class.send(:connection).visitor.compile b
-          }.join(' AND ')
-        elsif ActiveRecord::VERSION::MINOR >= 2 && Hash === conditions
-          table = Arel::Table.new(@model_class.send(:table_name))
-
-          conditions = ActiveRecord::PredicateBuilder.resolve_column_aliases @model_class, conditions
-          conditions = @model_class.send(:expand_hash_conditions_for_aggregates, conditions)
-
-          ActiveRecord::PredicateBuilder.build_from_hash(@model_class, conditions, table).map { |b|
-            @model_class.send(:connection).visitor.compile b
-          }.join(' AND ')
-        else
-          @model_class.send(:sanitize_sql, conditions)
-        end
       end
     end
   end

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -26,30 +26,7 @@ module CanCan
           end
         end
       end
-
-      def tableized_conditions(conditions, model_class = @model_class)
-        return conditions unless conditions.kind_of? Hash
-        conditions.inject({}) do |result_hash, (name, value)|
-          if value.kind_of? Hash
-            value = value.dup
-            association_class = model_class.reflect_on_association(name).klass.name.constantize
-            nested = value.inject({}) do |nested,(k,v)|
-              if v.kind_of? Hash
-                value.delete(k)
-                nested[k] = v
-              else
-                result_hash[model_class.reflect_on_association(name).table_name.to_sym] = value
-              end
-              nested
-            end
-            result_hash.merge!(tableized_conditions(nested,association_class))
-          else
-            result_hash[name] = value
-          end
-          result_hash
-        end
-      end
-
+      
       # Returns the associations used in conditions for the :joins option of a search.
       # See ModelAdditions#accessible_by
       def joins
@@ -75,6 +52,29 @@ module CanCan
       end
 
       private
+
+      def tableized_conditions(conditions, model_class = @model_class)
+        return conditions unless conditions.kind_of? Hash
+        conditions.inject({}) do |result_hash, (name, value)|
+          if value.kind_of? Hash
+            value = value.dup
+            association_class = model_class.reflect_on_association(name).klass.name.constantize
+            nested = value.inject({}) do |nested,(k,v)|
+              if v.kind_of? Hash
+                value.delete(k)
+                nested[k] = v
+              else
+                result_hash[model_class.reflect_on_association(name).table_name.to_sym] = value
+              end
+              nested
+            end
+            result_hash.merge!(tableized_conditions(nested,association_class))
+          else
+            result_hash[name] = value
+          end
+          result_hash
+        end
+      end
 
       def mergeable_conditions?
         @rules.find {|rule| rule.unmergeable? }.blank?

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -1,53 +1,38 @@
 module CanCan
   module ModelAdapters
     module ActiveRecordAdapter
-      # Returns conditions intended to be used inside a database query. Normally you will not call this
-      # method directly, but instead go through ModelAdditions#accessible_by.
-      #
-      # If there is only one "can" definition, a hash of conditions will be returned matching the one defined.
-      #
-      #   can :manage, User, :id => 1
-      #   query(:manage, User).conditions # => { :id => 1 }
-      #
-      # If there are multiple "can" definitions, a SQL string will be returned to handle complex cases.
-      #
-      #   can :manage, User, :id => 1
-      #   can :manage, User, :manager_id => 1
-      #   cannot :manage, User, :self_managed => true
-      #   query(:manage, User).conditions # => "not (self_managed = 't') AND ((manager_id = 1) OR (id = 1))"
-      #
-      def conditions
-        if @rules.size == 1 && @rules.first.base_behavior
-          # Return the conditions directly if there's just one definition
-          tableized_conditions(@rules.first.conditions).dup
+      def database_records
+        if override_scope
+          @model_class.where(nil).merge(override_scope)
         else
-          @rules.reverse.inject(false_sql) do |sql, rule|
-            merge_conditions(sql, tableized_conditions(rule.conditions).dup, rule.base_behavior)
+          positive_relations = []
+          negative_relations = []
+          @rules.reverse.each do |rule|
+            if rule.base_behavior
+              positive_relations << relation_for(rule)
+            else
+              negative_relations << relation_for(rule)
+            end
+          end
+          if positive_relations.empty?
+            @model_class.where('1 == 0')
+          else
+            positive_sql = positive_relations.map(&:to_sql).join(' UNION ')
+            if negative_relations.empty?
+              @model_class.select("DISTINCT #{@model_class.table_name}.*").from("(#{positive_sql}) AS #{@model_class.table_name}")
+            else
+              negative_sql = negative_relations.map(&:to_sql).join(' EXCEPT ')
+              @model_class.select("DISTINCT #{@model_class.table_name}.*").from("(#{positive_sql} EXCEPT #{negative_sql}) AS #{@model_class.table_name}")
+            end
           end
         end
       end
       
-      # Returns the associations used in conditions for the :joins option of a search.
-      # See ModelAdditions#accessible_by
-      def joins
-        joins_hash = {}
-        @rules.each do |rule|
-          merge_joins(joins_hash, rule.associations_hash)
-        end
-        clean_joins(joins_hash) unless joins_hash.empty?
-      end
-
-      def database_records
-        if override_scope
-          @model_class.where(nil).merge(override_scope)
-        elsif @model_class.respond_to?(:where) && @model_class.respond_to?(:joins)
-          build_relation(conditions)
-        else
-          @model_class.all(:conditions => conditions, :joins => joins)
-        end
-      end
-
       private
+
+      def relation_for(rule)
+        @model_class.where(tableized_conditions(rule.conditions)).joins(joins_for(rule))
+      end
 
       def tableized_conditions(conditions, model_class = @model_class)
         return conditions unless conditions.kind_of? Hash
@@ -84,43 +69,9 @@ module CanCan
         end
       end
 
-      def merge_conditions(sql, conditions_hash, behavior)
-        if conditions_hash.blank?
-          behavior ? true_sql : false_sql
-        else
-          conditions = sanitize_sql(conditions_hash)
-          case sql
-          when true_sql
-            behavior ? true_sql : "not (#{conditions})"
-          when false_sql
-            behavior ? conditions : false_sql
-          else
-            behavior ? "(#{conditions}) OR (#{sql})" : "not (#{conditions}) AND (#{sql})"
-          end
-        end
-      end
-
-      def false_sql
-        sanitize_sql(['?=?', true, false])
-      end
-
-      def true_sql
-        sanitize_sql(['?=?', true, true])
-      end
-
-      def sanitize_sql(conditions)
-        @model_class.send(:sanitize_sql, conditions)
-      end
-
-      # Takes two hashes and does a deep merge.
-      def merge_joins(base, add)
-        add.each do |name, nested|
-          if base[name].is_a?(Hash)
-            merge_joins(base[name], nested) unless nested.empty?
-          else
-            base[name] = nested
-          end
-        end
+      def joins_for(rule)
+        joins_hash = rule.associations_hash
+        clean_joins(joins_hash) unless joins_hash.empty?
       end
 
       # Removes empty hashes and moves everything into arrays.

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -41,11 +41,7 @@ module CanCan
         if override_scope
           @model_class.where(nil).merge(override_scope)
         elsif @model_class.respond_to?(:where) && @model_class.respond_to?(:joins)
-          if mergeable_conditions?
-            build_relation(conditions)
-          else
-            build_relation(*(@rules.map(&:conditions)))
-          end
+          build_relation(conditions)
         else
           @model_class.all(:conditions => conditions, :joins => joins)
         end
@@ -74,10 +70,6 @@ module CanCan
           end
           result_hash
         end
-      end
-
-      def mergeable_conditions?
-        @rules.find {|rule| rule.unmergeable? }.blank?
       end
 
       def override_scope

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -54,11 +54,6 @@ module CanCan
       @conditions == {} || @conditions.nil?
     end
 
-    def unmergeable?
-      @conditions.respond_to?(:keys) && @conditions.present? &&
-        (!@conditions.keys.first.kind_of? Symbol)
-    end
-
     def associations_hash(conditions = @conditions)
       hash = {}
       conditions.map do |name, value|

--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -37,16 +37,4 @@ describe CanCan::Rule do
     rule = CanCan::Rule.new(true, :read, Integer, nil, nil)
     expect(rule.associations_hash).to eq({})
   end
-
-  it "is not mergeable if conditions are not simple hashes" do
-    meta_where = OpenStruct.new(:name => 'metawhere', :column => 'test')
-    @conditions[meta_where] = :bar
-
-    expect(@rule).to be_unmergeable
-  end
-
-  it "is not mergeable if conditions is an empty hash" do
-    @conditions = {}
-    expect(@rule).to_not be_unmergeable
-  end
 end


### PR DESCRIPTION
Fixes #337. This change refactors `ActiveRecordAdapter`, making it possible for two rules within the same [class, action] tuple to refer to the same table with different (and previously incompatible) conditions, and have the resulting relation contain the expected conditions. 

Essentially, each rule is now built out as a separate relation, with its own 'private' namespace for joins and conditions. The resulting relations are then combined using SQL's `UNION` and `EXCEPT` clauses into a master relation. Previously, all of the rules' conditions and joins were combined into  master condition and join expressions which were then expressed within a single relation, making it impossible for two separate rules to contain distinct sets of conditions against the same external table.


