### PR TITLE
use only new ruby hash syntax

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -280,13 +280,6 @@ Style/GuardClause:
     - 'lib/cancan/controller_resource.rb'
     - 'lib/cancan/model_adapters/active_record_adapter.rb'
 
-# Offense count: 599
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-Style/HashSyntax:
-  Enabled: false
-
 # Offense count: 1
 Style/IfInsideElse:
   Exclude:

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -220,9 +220,9 @@ module CanCan
 
     def unauthorized_message(action, subject)
       keys = unauthorized_message_keys(action, subject)
-      variables = {:action => action.to_s}
+      variables = {action: action.to_s}
       variables[:subject] = (subject.class == Class ? subject : subject.class).to_s.underscore.humanize.downcase
-      message = I18n.translate(nil, variables.merge(:scope => :unauthorized, :default => keys + ['']))
+      message = I18n.translate(nil, variables.merge(scope: :unauthorized, default: keys + ['']))
       message.blank? ? nil : message
     end
 
@@ -260,7 +260,7 @@ module CanCan
     #     action: array_of_objects
     #   }
     def permissions
-      permissions_list = {:can => {}, :cannot => {}}
+      permissions_list = {can: {}, cannot: {}}
 
       rules.each do |rule|
         subjects = rule.subjects
@@ -412,9 +412,9 @@ module CanCan
 
     def default_alias_actions
       {
-        :read => [:index, :show],
-        :create => [:new],
-        :update => [:edit],
+        read: [:index, :show],
+        create: [:new],
+        update: [:edit],
       }
     end
   end

--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -292,7 +292,7 @@ module CanCan
       end
 
       def cancan_skipper
-        @_cancan_skipper ||= {:authorize => {}, :load => {}}
+        @_cancan_skipper ||= {authorize: {}, load: {}}
       end
     end
 

--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -40,7 +40,7 @@ module CanCan
       @message = message
       @action = action
       @subject = subject
-      @default_message = I18n.t(:"unauthorized.default", :default => 'You are not authorized to access this page.')
+      @default_message = I18n.t(:"unauthorized.default", default: 'You are not authorized to access this page.')
     end
 
     def to_s

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -70,7 +70,7 @@ module CanCan
             build_relation(*(@rules.map(&:conditions)))
           end
         else
-          @model_class.all(:conditions => conditions, :joins => joins)
+          @model_class.all(conditions: conditions, joins: joins)
         end
       end
 

--- a/lib/cancan/model_adapters/mongoid_adapter.rb
+++ b/lib/cancan/model_adapters/mongoid_adapter.rb
@@ -24,7 +24,7 @@ module CanCan
 
       def database_records
         if @rules.size == 0
-          @model_class.where(:_id => {'$exists' => false, '$type' => 7}) # return no records in Mongoid
+          @model_class.where(_id: {'$exists' => false, '$type' => 7}) # return no records in Mongoid
         elsif @rules.size == 1 && @rules[0].conditions.is_a?(Mongoid::Criteria)
           @rules[0].conditions
         else

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -96,21 +96,21 @@ describe CanCan::Ability do
   end
 
   it 'makes alias for update or destroy actions to modify action' do
-    @ability.alias_action :update, :destroy, :to => :modify
+    @ability.alias_action :update, :destroy, to: :modify
     @ability.can :modify, :all
     expect(@ability.can?(:update, 123)).to be(true)
     expect(@ability.can?(:destroy, 123)).to be(true)
   end
 
   it 'allows deeply nested aliased actions' do
-    @ability.alias_action :increment, :to => :sort
-    @ability.alias_action :sort, :to => :modify
+    @ability.alias_action :increment, to: :sort
+    @ability.alias_action :sort, to: :modify
     @ability.can :modify, :all
     expect(@ability.can?(:increment, 123)).to be(true)
   end
 
   it 'raises an Error if alias target is an exist action' do
-    expect { @ability.alias_action :show, :to => :show }.to raise_error(CanCan::Error, "You can't specify target (show) as alias because it is real action name")
+    expect { @ability.alias_action :show, to: :show }.to raise_error(CanCan::Error, "You can't specify target (show) as alias because it is real action name")
   end
 
   it 'always calls block with arguments when passing no arguments to can' do
@@ -172,10 +172,10 @@ describe CanCan::Ability do
 
   it 'checks if there is a permission for any of given subjects' do
     @ability.can :update, [String, Range]
-    expect(@ability.can?(:update, {:any => ['foo', 1..3]})).to be(true)
-    expect(@ability.can?(:update, {:any => [1..3, 'foo']})).to be(true)
-    expect(@ability.can?(:update, {:any => [123, 'foo']})).to be(true)
-    expect(@ability.can?(:update, {:any => [123, 1.0]})).to be(false)
+    expect(@ability.can?(:update, {any: ['foo', 1..3]})).to be(true)
+    expect(@ability.can?(:update, {any: [1..3, 'foo']})).to be(true)
+    expect(@ability.can?(:update, {any: [123, 'foo']})).to be(true)
+    expect(@ability.can?(:update, {any: [123, 1.0]})).to be(false)
   end
 
   it 'lists all permissions' do
@@ -185,13 +185,13 @@ describe CanCan::Ability do
     @ability.cannot :read, Hash
     @ability.cannot :preview, Array
 
-    expected_list = {:can => {:manage => ['all'],
-                              :learn => ['Range']
+    expected_list = {can: {manage: ['all'],
+                              learn: ['Range']
                              },
-                     :cannot => {:read => ['String', 'Hash'],
-                                 :index => ['String', 'Hash'],
-                                 :show => ['String', 'Hash'],
-                                 :preview => ['Array']
+                     cannot: {read: ['String', 'Hash'],
+                                 index: ['String', 'Hash'],
+                                 show: ['String', 'Hash'],
+                                 preview: ['Array']
                                 }
                     }
 
@@ -203,8 +203,8 @@ describe CanCan::Ability do
     expect(@ability.can?(:read, :stats)).to be(true)
     expect(@ability.can?(:update, :stats)).to be(false)
     expect(@ability.can?(:read, :nonstats)).to be(false)
-    expect(@ability.can?(:read, {:any => [:stats, :nonstats]})).to be(true)
-    expect(@ability.can?(:read, {:any => [:nonstats, :neitherstats]})).to be(false)
+    expect(@ability.can?(:read, {any: [:stats, :nonstats]})).to be(true)
+    expect(@ability.can?(:read, {any: [:nonstats, :neitherstats]})).to be(false)
   end
 
   it 'checks ancestors of class' do
@@ -212,7 +212,7 @@ describe CanCan::Ability do
     expect(@ability.can?(:read, Integer)).to be(true)
     expect(@ability.can?(:read, 1.23)).to be(true)
     expect(@ability.can?(:read, 'foo')).to be(false)
-    expect(@ability.can?(:read, {:any => [Integer, String]})).to be(true)
+    expect(@ability.can?(:read, {any: [Integer, String]})).to be(true)
   end
 
   it "supports 'cannot' method to define what user cannot do" do
@@ -220,9 +220,9 @@ describe CanCan::Ability do
     @ability.cannot :read, Integer
     expect(@ability.can?(:read, 'foo')).to be(true)
     expect(@ability.can?(:read, 123)).to be(false)
-    expect(@ability.can?(:read, {:any => ['foo', 'bar']})).to be(true)
-    expect(@ability.can?(:read, {:any => [123, 'foo']})).to be(false)
-    expect(@ability.can?(:read, {:any => [123, 456]})).to be(false)
+    expect(@ability.can?(:read, {any: ['foo', 'bar']})).to be(true)
+    expect(@ability.can?(:read, {any: [123, 'foo']})).to be(false)
+    expect(@ability.can?(:read, {any: [123, 456]})).to be(false)
   end
 
   it 'passes to previous rule, if block returns false or nil' do
@@ -235,8 +235,8 @@ describe CanCan::Ability do
     expect(@ability.can?(:read, 3)).to be(true)
     expect(@ability.can?(:read, 8)).to be(false)
     expect(@ability.can?(:read, 123)).to be(true)
-    expect(@ability.can?(:read, {:any => [123, 8]})).to be(true)
-    expect(@ability.can?(:read, {:any => [8, 9]})).to be(false)
+    expect(@ability.can?(:read, {any: [123, 8]})).to be(true)
+    expect(@ability.can?(:read, {any: [8, 9]})).to be(false)
   end
 
   it 'always returns `false` for single cannot definition' do
@@ -261,13 +261,13 @@ describe CanCan::Ability do
   end
 
   it 'appends aliased actions' do
-    @ability.alias_action :update, :to => :modify
-    @ability.alias_action :destroy, :to => :modify
+    @ability.alias_action :update, to: :modify
+    @ability.alias_action :destroy, to: :modify
     expect(@ability.aliased_actions[:modify]).to eq([:update, :destroy])
   end
 
   it 'clears aliased actions' do
-    @ability.alias_action :update, :to => :modify
+    @ability.alias_action :update, to: :modify
     @ability.clear_aliased_actions
     expect(@ability.aliased_actions[:modify]).to be_nil
   end
@@ -279,80 +279,80 @@ describe CanCan::Ability do
 
     expect(@ability.can?(:read, 2, 1)).to be(true)
     expect(@ability.can?(:read, 2, 3)).to be(false)
-    expect(@ability.can?(:read, {:any => [4, 5]}, 3)).to be(true)
-    expect(@ability.can?(:read, {:any => [2, 3]}, 3)).to be(false)
+    expect(@ability.can?(:read, {any: [4, 5]}, 3)).to be(true)
+    expect(@ability.can?(:read, {any: [2, 3]}, 3)).to be(false)
   end
 
   it 'uses conditions as third parameter and determine abilities from it' do
-    @ability.can :read, Range, :begin => 1, :end => 3
+    @ability.can :read, Range, begin: 1, end: 3
 
     expect(@ability.can?(:read, 1..3)).to be(true)
     expect(@ability.can?(:read, 1..4)).to be(false)
     expect(@ability.can?(:read, Range)).to be(true)
-    expect(@ability.can?(:read, {:any => [1..3, 1..4]})).to be(true)
-    expect(@ability.can?(:read, {:any => [1..4, 2..4]})).to be(false)
+    expect(@ability.can?(:read, {any: [1..3, 1..4]})).to be(true)
+    expect(@ability.can?(:read, {any: [1..4, 2..4]})).to be(false)
   end
 
   it 'allows an array of options in conditions hash' do
-    @ability.can :read, Range, :begin => [1, 3, 5]
+    @ability.can :read, Range, begin: [1, 3, 5]
 
     expect(@ability.can?(:read, 1..3)).to be(true)
     expect(@ability.can?(:read, 2..4)).to be(false)
     expect(@ability.can?(:read, 3..5)).to be(true)
-    expect(@ability.can?(:read, {:any => [2..4, 3..5]})).to be(true)
-    expect(@ability.can?(:read, {:any => [2..4, 2..5]})).to be(false)
+    expect(@ability.can?(:read, {any: [2..4, 3..5]})).to be(true)
+    expect(@ability.can?(:read, {any: [2..4, 2..5]})).to be(false)
   end
 
   it 'allows a range of options in conditions hash' do
-    @ability.can :read, Range, :begin => 1..3
+    @ability.can :read, Range, begin: 1..3
     expect(@ability.can?(:read, 1..10)).to be(true)
     expect(@ability.can?(:read, 3..30)).to be(true)
     expect(@ability.can?(:read, 4..40)).to be(false)
   end
 
   it 'allows a range of time in conditions hash' do
-    @ability.can :read, Range, :begin => 1.day.from_now..3.days.from_now
+    @ability.can :read, Range, begin: 1.day.from_now..3.days.from_now
     expect(@ability.can?(:read, 1.day.from_now..10.days.from_now)).to be(true)
     expect(@ability.can?(:read, 2.days.from_now..20.days.from_now)).to be(true)
     expect(@ability.can?(:read, 4.days.from_now..40.days.from_now)).to be(false)
   end
 
   it 'allows nested hashes in conditions hash' do
-    @ability.can :read, Range, :begin => { :to_i => 5 }
+    @ability.can :read, Range, begin: { to_i: 5 }
     expect(@ability.can?(:read, 5..7)).to be(true)
     expect(@ability.can?(:read, 6..8)).to be(false)
   end
 
   it "matches any element passed in to nesting if it's an array (for has_many associations)" do
-    @ability.can :read, Range, :to_a => { :to_i => 3 }
+    @ability.can :read, Range, to_a: { to_i: 3 }
     expect(@ability.can?(:read, 1..5)).to be(true)
     expect(@ability.can?(:read, 4..6)).to be(false)
   end
 
   it 'accepts a set as a condition value' do
-    expect(object_with_foo_2 = double(:foo => 2)).to receive(:foo)
-    expect(object_with_foo_3 = double(:foo => 3)).to receive(:foo)
-    @ability.can :read, Object, :foo => [1, 2, 5].to_set
+    expect(object_with_foo_2 = double(foo: 2)).to receive(:foo)
+    expect(object_with_foo_3 = double(foo: 3)).to receive(:foo)
+    @ability.can :read, Object, foo: [1, 2, 5].to_set
     expect(@ability.can?(:read, object_with_foo_2)).to be(true)
     expect(@ability.can?(:read, object_with_foo_3)).to be(false)
   end
 
   it 'does not match subjects return nil for methods that must match nested a nested conditions hash' do
-    expect(object_with_foo = double(:foo => :bar)).to receive(:foo)
-    @ability.can :read, Array, :first => { :foo => :bar }
+    expect(object_with_foo = double(foo: :bar)).to receive(:foo)
+    @ability.can :read, Array, first: { foo: :bar }
     expect(@ability.can?(:read, [object_with_foo])).to be(true)
     expect(@ability.can?(:read, [])).to be(false)
   end
 
   it 'matches strings but not substrings specified in a conditions hash' do
-    @ability.can :read, String, :presence => 'declassified'
+    @ability.can :read, String, presence: 'declassified'
     expect(@ability.can?(:read, 'declassified')).to be(true)
     expect(@ability.can?(:read, 'classified')).to be(false)
   end
 
   it 'does not stop at cannot definition when comparing class' do
     @ability.can :read, Range
-    @ability.cannot :read, Range, :begin => 1
+    @ability.cannot :read, Range, begin: 1
     expect(@ability.can?(:read, 2..5)).to be(true)
     expect(@ability.can?(:read, 1..5)).to be(false)
     expect(@ability.can?(:read, Range)).to be(true)
@@ -385,24 +385,24 @@ describe CanCan::Ability do
   end
 
   it 'checks permissions through association when passing a hash of subjects' do
-    @ability.can :read, Range, :string => {:length => 3}
+    @ability.can :read, Range, string: {length: 3}
 
     expect(@ability.can?(:read, 'foo' => Range)).to be(true)
     expect(@ability.can?(:read, 'foobar' => Range)).to be(false)
     expect(@ability.can?(:read, 123 => Range)).to be(true)
-    expect(@ability.can?(:read, {:any => [{'foo' => Range}, {'foobar' => Range}]})).to be(true)
-    expect(@ability.can?(:read, {:any => [{'food' => Range}, {'foobar' => Range}]})).to be(false)
+    expect(@ability.can?(:read, {any: [{'foo' => Range}, {'foobar' => Range}]})).to be(true)
+    expect(@ability.can?(:read, {any: [{'food' => Range}, {'foobar' => Range}]})).to be(false)
   end
 
   it 'checks permissions correctly when passing a hash of subjects with multiple definitions' do
-    @ability.can :read, Range, :string => {:length => 4}
-    @ability.can [:create, :read], Range, :string => {:upcase => 'FOO'}
+    @ability.can :read, Range, string: {length: 4}
+    @ability.can [:create, :read], Range, string: {upcase: 'FOO'}
 
     expect(@ability.can?(:read, 'foo' => Range)).to be(true)
     expect(@ability.can?(:read, 'foobar' => Range)).to be(false)
     expect(@ability.can?(:read, 1234 => Range)).to be(true)
-    expect(@ability.can?(:read, {:any => [{'foo' => Range}, {'foobar' => Range}]})).to be(true)
-    expect(@ability.can?(:read, {:any => [{'foo.bar' => Range}, {'foobar' => Range}]})).to be(false)
+    expect(@ability.can?(:read, {any: [{'foo' => Range}, {'foobar' => Range}]})).to be(true)
+    expect(@ability.can?(:read, {any: [{'foo.bar' => Range}, {'foobar' => Range}]})).to be(false)
   end
 
   it 'allows to check ability on Hash-like object' do
@@ -412,16 +412,16 @@ describe CanCan::Ability do
   end
 
   it "has initial attributes based on hash conditions of 'new' action" do
-    @ability.can :manage, Range, :foo => 'foo', :hash => {:skip => 'hashes'}
-    @ability.can :create, Range, :bar => 123, :array => %w[skip arrays]
-    @ability.can :new, Range, :baz => 'baz', :range => 1..3
-    @ability.cannot :new, Range, :ignore => 'me'
-    expect(@ability.attributes_for(:new, Range)).to eq({:foo => 'foo', :bar => 123, :baz => 'baz'})
+    @ability.can :manage, Range, foo: 'foo', hash: {skip: 'hashes'}
+    @ability.can :create, Range, bar: 123, array: %w[skip arrays]
+    @ability.can :new, Range, baz: 'baz', range: 1..3
+    @ability.cannot :new, Range, ignore: 'me'
+    expect(@ability.attributes_for(:new, Range)).to eq({foo: 'foo', bar: 123, baz: 'baz'})
   end
 
   it 'raises access denied exception if ability us unauthorized to perform a certain action' do
     begin
-      @ability.authorize! :read, :foo, 1, 2, 3, :message => 'Access denied!'
+      @ability.authorize! :read, :foo, 1, 2, 3, message: 'Access denied!'
     rescue CanCan::AccessDenied => e
       expect(e.message).to eq('Access denied!')
       expect(e.action).to eq(:read)
@@ -474,7 +474,7 @@ describe CanCan::Ability do
 
   it "raises an error when attempting to use a block with a hash condition since it's not likely what they want" do
     expect {
-      @ability.can :read, Array, :published => true do
+      @ability.can :read, Array, published: true do
         false
       end
     }.to raise_error(CanCan::Error, 'You are not able to supply a block with a hash of conditions in read Array ability. Use either one.')
@@ -486,21 +486,21 @@ describe CanCan::Ability do
     end
 
     it 'uses action/subject in i18n' do
-      I18n.backend.store_translations :en, :unauthorized => {:update => {:array => 'foo'}}
+      I18n.backend.store_translations :en, unauthorized: {update: {array: 'foo'}}
       expect(@ability.unauthorized_message(:update, Array)).to eq('foo')
       expect(@ability.unauthorized_message(:update, [1, 2, 3])).to eq('foo')
       expect(@ability.unauthorized_message(:update, :missing)).to be_nil
     end
 
     it 'uses symbol as subject directly' do
-      I18n.backend.store_translations :en, :unauthorized => {:has => {:cheezburger => 'Nom nom nom. I eated it.'}}
+      I18n.backend.store_translations :en, unauthorized: {has: {cheezburger: 'Nom nom nom. I eated it.'}}
       expect(@ability.unauthorized_message(:has, :cheezburger)).to eq('Nom nom nom. I eated it.')
     end
 
     it "falls back to 'manage' and 'all'" do
-      I18n.backend.store_translations :en, :unauthorized => {
-        :manage => {:all => 'manage all', :array => 'manage array'},
-        :update => {:all => 'update all', :array => 'update array'}
+      I18n.backend.store_translations :en, unauthorized: {
+        manage: {all: 'manage all', array: 'manage array'},
+        update: {all: 'update all', array: 'update array'}
       }
       expect(@ability.unauthorized_message(:update, Array)).to eq('update array')
       expect(@ability.unauthorized_message(:update, Hash)).to eq('update all')
@@ -509,14 +509,14 @@ describe CanCan::Ability do
     end
 
     it 'follows aliased actions' do
-      I18n.backend.store_translations :en, :unauthorized => {:modify => {:array => 'modify array'}}
-      @ability.alias_action :update, :to => :modify
+      I18n.backend.store_translations :en, unauthorized: {modify: {array: 'modify array'}}
+      @ability.alias_action :update, to: :modify
       expect(@ability.unauthorized_message(:update, Array)).to eq('modify array')
       expect(@ability.unauthorized_message(:edit, Array)).to eq('modify array')
     end
 
     it 'has variables for action and subject' do
-      I18n.backend.store_translations :en, :unauthorized => {:manage => {:all => '%{action} %{subject}'}} # old syntax for now in case testing with old I18n
+      I18n.backend.store_translations :en, unauthorized: {manage: {all: '%{action} %{subject}'}} # old syntax for now in case testing with old I18n
       expect(@ability.unauthorized_message(:update, Array)).to eq('update array')
       expect(@ability.unauthorized_message(:update, ArgumentError)).to eq('update argument error')
       expect(@ability.unauthorized_message(:edit, 1..3)).to eq('edit range')

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -186,12 +186,12 @@ describe CanCan::Ability do
     @ability.cannot :preview, Array
 
     expected_list = {can: {manage: ['all'],
-                              learn: ['Range']
+                           learn: ['Range']
                              },
                      cannot: {read: ['String', 'Hash'],
-                                 index: ['String', 'Hash'],
-                                 show: ['String', 'Hash'],
-                                 preview: ['Array']
+                              index: ['String', 'Hash'],
+                              show: ['String', 'Hash'],
+                              preview: ['Array']
                                 }
                     }
 

--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -32,35 +32,35 @@ describe CanCan::ControllerAdditions do
 
   it 'load_and_authorize_resource setups a before filter which passes call to ControllerResource' do
     expect(cancan_resource_class = double).to receive(:load_and_authorize_resource)
-    allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, :foo => :bar) {cancan_resource_class }
+    allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, foo: :bar) {cancan_resource_class }
     expect(@controller_class).to receive(callback_action(:before_action)).with({}) { |options, &block| block.call(@controller) }
-    @controller_class.load_and_authorize_resource :foo => :bar
+    @controller_class.load_and_authorize_resource foo: :bar
   end
 
   it 'load_and_authorize_resource properly passes first argument as the resource name' do
     expect(cancan_resource_class = double).to receive(:load_and_authorize_resource)
-    allow(CanCan::ControllerResource).to receive(:new).with(@controller, :project, :foo => :bar) {cancan_resource_class}
+    allow(CanCan::ControllerResource).to receive(:new).with(@controller, :project, foo: :bar) {cancan_resource_class}
     expect(@controller_class).to receive(callback_action(:before_action)).with({}) { |options, &block| block.call(@controller) }
-    @controller_class.load_and_authorize_resource :project, :foo => :bar
+    @controller_class.load_and_authorize_resource :project, foo: :bar
   end
 
   it 'load_and_authorize_resource with :prepend prepends the before filter' do
     expect(@controller_class).to receive(callback_action(:prepend_before_action)).with({})
-    @controller_class.load_and_authorize_resource :foo => :bar, :prepend => true
+    @controller_class.load_and_authorize_resource foo: :bar, prepend: true
   end
 
   it 'authorize_resource setups a before filter which passes call to ControllerResource' do
     expect(cancan_resource_class = double).to receive(:authorize_resource)
-    allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, :foo => :bar) {cancan_resource_class}
-    expect(@controller_class).to receive(callback_action(:before_action)).with(:except => :show, :if => true) { |options, &block| block.call(@controller) }
-    @controller_class.authorize_resource :foo => :bar, :except => :show, :if => true
+    allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, foo: :bar) {cancan_resource_class}
+    expect(@controller_class).to receive(callback_action(:before_action)).with(except: :show, if: true) { |options, &block| block.call(@controller) }
+    @controller_class.authorize_resource foo: :bar, except: :show, if: true
   end
 
   it 'load_resource setups a before filter which passes call to ControllerResource' do
     expect(cancan_resource_class = double).to receive(:load_resource)
-    allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, :foo => :bar) {cancan_resource_class}
-    expect(@controller_class).to receive(callback_action(:before_action)).with(:only => [:show, :index], :unless => false) { |options, &block| block.call(@controller) }
-    @controller_class.load_resource :foo => :bar, :only => [:show, :index], :unless => false
+    allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, foo: :bar) {cancan_resource_class}
+    expect(@controller_class).to receive(callback_action(:before_action)).with(only: [:show, :index], unless: false) { |options, &block| block.call(@controller) }
+    @controller_class.load_resource foo: :bar, only: [:show, :index], unless: false
   end
 
   it 'skip_authorization_check setups a before filter which sets @_authorized to true' do
@@ -70,9 +70,9 @@ describe CanCan::ControllerAdditions do
   end
 
   it 'check_authorization triggers AuthorizationNotPerformed in after filter' do
-    expect(@controller_class).to receive(callback_action(:after_action)).with(:only => [:test]) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(callback_action(:after_action)).with(only: [:test]) { |options, &block| block.call(@controller) }
     expect {
-      @controller_class.check_authorization(:only => [:test])
+      @controller_class.check_authorization(only: [:test])
     }.to raise_error(CanCan::AuthorizationNotPerformed)
   end
 
@@ -80,7 +80,7 @@ describe CanCan::ControllerAdditions do
     allow(@controller).to receive(:check_auth?) { false }
     allow(@controller_class).to receive(callback_action(:after_action)).with({}) { |options, &block| block.call(@controller) }
     expect {
-      @controller_class.check_authorization(:if => :check_auth?)
+      @controller_class.check_authorization(if: :check_auth?)
     }.not_to raise_error
   end
 
@@ -88,15 +88,15 @@ describe CanCan::ControllerAdditions do
     allow(@controller).to receive(:engine_controller?) { true }
     expect(@controller_class).to receive(callback_action(:after_action)).with({}) { |options, &block| block.call(@controller) }
     expect {
-      @controller_class.check_authorization(:unless => :engine_controller?)
+      @controller_class.check_authorization(unless: :engine_controller?)
     }.not_to raise_error
   end
 
   it 'check_authorization does not raise error when @_authorized is set' do
     @controller.instance_variable_set(:@_authorized, true)
-    expect(@controller_class).to receive(callback_action(:after_action)).with(:only => [:test]) { |options, &block| block.call(@controller) }
+    expect(@controller_class).to receive(callback_action(:after_action)).with(only: [:test]) { |options, &block| block.call(@controller) }
     expect {
-      @controller_class.check_authorization(:only => [:test])
+      @controller_class.check_authorization(only: [:test])
     }.not_to raise_error
   end
 
@@ -110,33 +110,33 @@ describe CanCan::ControllerAdditions do
   end
 
   it 'cancan_skipper is an empty hash with :authorize and :load options and remember changes' do
-    expect(@controller_class.cancan_skipper).to eq({:authorize => {}, :load => {}})
+    expect(@controller_class.cancan_skipper).to eq({authorize: {}, load: {}})
     @controller_class.cancan_skipper[:load] = true
     expect(@controller_class.cancan_skipper[:load]).to be(true)
   end
 
   it 'skip_authorize_resource adds itself to the cancan skipper with given model name and options' do
-    @controller_class.skip_authorize_resource(:project, :only => [:index, :show])
-    expect(@controller_class.cancan_skipper[:authorize][:project]).to eq({:only => [:index, :show]})
-    @controller_class.skip_authorize_resource(:only => [:index, :show])
-    expect(@controller_class.cancan_skipper[:authorize][nil]).to eq({:only => [:index, :show]})
+    @controller_class.skip_authorize_resource(:project, only: [:index, :show])
+    expect(@controller_class.cancan_skipper[:authorize][:project]).to eq({only: [:index, :show]})
+    @controller_class.skip_authorize_resource(only: [:index, :show])
+    expect(@controller_class.cancan_skipper[:authorize][nil]).to eq({only: [:index, :show]})
     @controller_class.skip_authorize_resource(:article)
     expect(@controller_class.cancan_skipper[:authorize][:article]).to eq({})
   end
 
   it 'skip_load_resource adds itself to the cancan skipper with given model name and options' do
-    @controller_class.skip_load_resource(:project, :only => [:index, :show])
-    expect(@controller_class.cancan_skipper[:load][:project]).to eq({:only => [:index, :show]})
-    @controller_class.skip_load_resource(:only => [:index, :show])
-    expect(@controller_class.cancan_skipper[:load][nil]).to eq({:only => [:index, :show]})
+    @controller_class.skip_load_resource(:project, only: [:index, :show])
+    expect(@controller_class.cancan_skipper[:load][:project]).to eq({only: [:index, :show]})
+    @controller_class.skip_load_resource(only: [:index, :show])
+    expect(@controller_class.cancan_skipper[:load][nil]).to eq({only: [:index, :show]})
     @controller_class.skip_load_resource(:article)
     expect(@controller_class.cancan_skipper[:load][:article]).to eq({})
   end
 
   it 'skip_load_and_authore_resource adds itself to the cancan skipper with given model name and options' do
-    @controller_class.skip_load_and_authorize_resource(:project, :only => [:index, :show])
-    expect(@controller_class.cancan_skipper[:load][:project]).to eq({:only => [:index, :show]})
-    expect(@controller_class.cancan_skipper[:authorize][:project]).to eq({:only => [:index, :show]})
+    @controller_class.skip_load_and_authorize_resource(:project, only: [:index, :show])
+    expect(@controller_class.cancan_skipper[:load][:project]).to eq({only: [:index, :show]})
+    expect(@controller_class.cancan_skipper[:authorize][:project]).to eq({only: [:index, :show]})
   end
 
   private

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe CanCan::ControllerResource do
   let(:ability) { Ability.new(nil) }
-  let(:params) { HashWithIndifferentAccess.new(:controller => 'models') }
+  let(:params) { HashWithIndifferentAccess.new(controller: 'models') }
   let(:controller_class) { Class.new }
   let(:controller) { controller_class.new }
 
@@ -19,33 +19,33 @@ describe CanCan::ControllerResource do
 
     allow(controller).to receive(:params) { params }
     allow(controller).to receive(:current_ability) { ability }
-    allow(controller_class).to receive(:cancan_skipper) { {:authorize => {}, :load => {}} }
+    allow(controller_class).to receive(:cancan_skipper) { {authorize: {}, load: {}} }
   end
 
   context 'on build actions' do
     before :each do
-      params.merge!(:action => 'new')
+      params.merge!(action: 'new')
     end
 
     it 'builds a new resource with attributes from current ability' do
-      ability.can(:create, Model, :name => 'from conditions')
+      ability.can(:create, Model, name: 'from conditions')
       resource = CanCan::ControllerResource.new(controller)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq('from conditions')
     end
 
     it 'overrides initial attributes with params' do
-      params.merge!(:model => {:name => 'from params'})
-      ability.can(:create, Model, :name => 'from conditions')
+      params.merge!(model: {name: 'from params'})
+      ability.can(:create, Model, name: 'from conditions')
       resource = CanCan::ControllerResource.new(controller)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq('from params')
     end
 
     it 'builds a resource when on custom new action even when params[:id] exists' do
-      params.merge!(:action => 'build', :id => '123')
+      params.merge!(action: 'build', id: '123')
       allow(Model).to receive(:new) { :some_model }
-      resource = CanCan::ControllerResource.new(controller, :new => :build)
+      resource = CanCan::ControllerResource.new(controller, new: :build)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(:some_model)
     end
@@ -54,16 +54,16 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:find).with('123') { model }
 
-      params.merge!(:model_id => 123)
+      params.merge!(model_id: 123)
       allow(controller).to receive(:authorize!).with(:show, model) { raise CanCan::AccessDenied }
-      resource = CanCan::ControllerResource.new(controller, :model, :parent => true)
+      resource = CanCan::ControllerResource.new(controller, :model, parent: true)
       expect { resource.load_and_authorize_resource }.to raise_error(CanCan::AccessDenied)
     end
   end
 
   context 'on create actions' do
     before :each do
-      params.merge!(:action => 'create')
+      params.merge!(action: 'create')
     end
 
     # Rails includes namespace in params, see issue #349
@@ -72,14 +72,14 @@ describe CanCan::ControllerResource do
         class Model < ::Model; end
       end
 
-      params.merge!(:controller => 'my_engine/models', :my_engine_model => {:name => 'foobar'})
+      params.merge!(controller: 'my_engine/models', my_engine_model: {name: 'foobar'})
       resource = CanCan::ControllerResource.new(controller)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq('foobar')
     end
 
     it 'builds a new resource with hash if params[:id] is not specified' do
-      params.merge!(:model => {:name => 'foobar'})
+      params.merge!(model: {name: 'foobar'})
       resource = CanCan::ControllerResource.new(controller)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq('foobar')
@@ -90,15 +90,15 @@ describe CanCan::ControllerResource do
         class Model < ::Model; end
       end
 
-      params.merge!('sub_model' => {:name => 'foobar'})
-      resource = CanCan::ControllerResource.new(controller, :class => ::Sub::Model)
+      params.merge!('sub_model' => {name: 'foobar'})
+      resource = CanCan::ControllerResource.new(controller, class: ::Sub::Model)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq('foobar')
     end
 
     it 'builds a new resource for namespaced controller and namespaced model with hash if params[:id] is not specified' do
-      params.merge!(:controller => 'admin/sub_models', 'sub_model' => {:name => 'foobar'})
-      resource = CanCan::ControllerResource.new(controller, :class => Model)
+      params.merge!(:controller => 'admin/sub_models', 'sub_model' => {name: 'foobar'})
+      resource = CanCan::ControllerResource.new(controller, class: Model)
       resource.load_resource
       expect(controller.instance_variable_get(:@sub_model).name).to eq('foobar')
     end
@@ -109,7 +109,7 @@ describe CanCan::ControllerResource do
           class HiddenModel < ::Model; end
         end
       end
-      params.merge!(:controller => 'admin/sub_module/hidden_models')
+      params.merge!(controller: 'admin/sub_module/hidden_models')
       resource = CanCan::ControllerResource.new(controller)
       expect { resource.load_resource }.not_to raise_error
     end
@@ -119,68 +119,68 @@ describe CanCan::ControllerResource do
       allow_any_instance_of(Model).to receive('category=').with(category)
       allow_any_instance_of(Model).to receive('category') { category }
 
-      params.merge!(:model => {:name => 'foobar'})
+      params.merge!(model: {name: 'foobar'})
 
       controller.instance_variable_set(:@category, category)
-      resource = CanCan::ControllerResource.new(controller, :through => :category, :singleton => true)
+      resource = CanCan::ControllerResource.new(controller, through: :category, singleton: true)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq('foobar')
       expect(controller.instance_variable_get(:@model).category).to eq(category)
     end
 
     it 'builds record through has_one association with :singleton and :shallow options' do
-      params.merge!(:model => {:name => 'foobar'})
-      resource = CanCan::ControllerResource.new(controller, :through => :category, :singleton => true, :shallow => true)
+      params.merge!(model: {name: 'foobar'})
+      resource = CanCan::ControllerResource.new(controller, through: :category, singleton: true, shallow: true)
       resource.load_resource
       expect(controller.instance_variable_get(:@model).name).to eq('foobar')
     end
 
     context 'with a strong parameters method' do
       before :each do
-        params.merge!(:controller => 'model', :model => { :name => 'test'})
+        params.merge!(controller: 'model', model: { name: 'test'})
       end
 
       it 'accepts and uses the specified symbol for santitizing input' do
-        allow(controller).to receive(:resource_params).and_return(:resource => 'params')
-        allow(controller).to receive(:model_params).and_return(:model => 'params')
-        allow(controller).to receive(:create_params).and_return(:create => 'params')
-        allow(controller).to receive(:custom_params).and_return(:custom => 'params')
-        resource = CanCan::ControllerResource.new(controller, {:param_method => :custom_params})
-        expect(resource.send('resource_params')).to eq(:custom => 'params')
+        allow(controller).to receive(:resource_params).and_return(resource: 'params')
+        allow(controller).to receive(:model_params).and_return(model: 'params')
+        allow(controller).to receive(:create_params).and_return(create: 'params')
+        allow(controller).to receive(:custom_params).and_return(custom: 'params')
+        resource = CanCan::ControllerResource.new(controller, {param_method: :custom_params})
+        expect(resource.send('resource_params')).to eq(custom: 'params')
       end
 
       it 'accepts the specified string for sanitizing input' do
-        resource = CanCan::ControllerResource.new(controller, {:param_method => "{:custom => 'params'}"})
-        expect(resource.send('resource_params')).to eq(:custom => 'params')
+        resource = CanCan::ControllerResource.new(controller, {param_method: "{:custom => 'params'}"})
+        expect(resource.send('resource_params')).to eq(custom: 'params')
       end
 
       it 'accepts the specified proc for sanitizing input' do
-        resource = CanCan::ControllerResource.new(controller, {:param_method => Proc.new { |c| {:custom => 'params'}}})
-        expect(resource.send('resource_params')).to eq(:custom => 'params')
+        resource = CanCan::ControllerResource.new(controller, {param_method: Proc.new { |c| {custom: 'params'}}})
+        expect(resource.send('resource_params')).to eq(custom: 'params')
       end
 
       it 'prefers to use the create_params method for santitizing input' do
-        allow(controller).to receive(:resource_params).and_return(:resource => 'params')
-        allow(controller).to receive(:model_params).and_return(:model => 'params')
-        allow(controller).to receive(:create_params).and_return(:create => 'params')
-        allow(controller).to receive(:custom_params).and_return(:custom => 'params')
+        allow(controller).to receive(:resource_params).and_return(resource: 'params')
+        allow(controller).to receive(:model_params).and_return(model: 'params')
+        allow(controller).to receive(:create_params).and_return(create: 'params')
+        allow(controller).to receive(:custom_params).and_return(custom: 'params')
         resource = CanCan::ControllerResource.new(controller)
-        expect(resource.send('resource_params')).to eq(:create => 'params')
+        expect(resource.send('resource_params')).to eq(create: 'params')
       end
 
       it 'prefers to use the <model_name>_params method for santitizing input if create is not found' do
-        allow(controller).to receive(:resource_params).and_return(:resource => 'params')
-        allow(controller).to receive(:model_params).and_return(:model => 'params')
-        allow(controller).to receive(:custom_params).and_return(:custom => 'params')
+        allow(controller).to receive(:resource_params).and_return(resource: 'params')
+        allow(controller).to receive(:model_params).and_return(model: 'params')
+        allow(controller).to receive(:custom_params).and_return(custom: 'params')
         resource = CanCan::ControllerResource.new(controller)
-        expect(resource.send('resource_params')).to eq(:model => 'params')
+        expect(resource.send('resource_params')).to eq(model: 'params')
       end
 
       it 'prefers to use the resource_params method for santitizing input if create or model is not found' do
-        allow(controller).to receive(:resource_params).and_return(:resource => 'params')
-        allow(controller).to receive(:custom_params).and_return(:custom => 'params')
+        allow(controller).to receive(:resource_params).and_return(resource: 'params')
+        allow(controller).to receive(:custom_params).and_return(custom: 'params')
         resource = CanCan::ControllerResource.new(controller)
-        expect(resource.send('resource_params')).to eq(:resource => 'params')
+        expect(resource.send('resource_params')).to eq(resource: 'params')
       end
     end
   end
@@ -227,7 +227,7 @@ describe CanCan::ControllerResource do
       controller.instance_variable_set(:@category, :some_category)
       allow(controller).to receive(:authorize!).with(:show, :some_category) { raise CanCan::AccessDenied }
 
-      resource = CanCan::ControllerResource.new(controller, :category, :parent => true)
+      resource = CanCan::ControllerResource.new(controller, :category, parent: true)
       expect { resource.authorize_resource }.to raise_error(CanCan::AccessDenied)
     end
 
@@ -235,7 +235,7 @@ describe CanCan::ControllerResource do
       controller.instance_variable_set(:@category, :some_category)
       allow(controller).to receive(:authorize!).with(:custom_action, :some_category) { raise CanCan::AccessDenied }
 
-      resource = CanCan::ControllerResource.new(controller, :category, :parent => true, :parent_action => :custom_action )
+      resource = CanCan::ControllerResource.new(controller, :category, parent: true, parent_action: :custom_action )
       expect { resource.authorize_resource }.to raise_error(CanCan::AccessDenied)
     end
 
@@ -244,15 +244,15 @@ describe CanCan::ControllerResource do
         class Dashboard; end
       end
       ability.can(:index, 'admin/dashboard')
-      params.merge!(:controller => 'admin/dashboard')
-      resource = CanCan::ControllerResource.new(controller, :authorize => true)
+      params.merge!(controller: 'admin/dashboard')
+      resource = CanCan::ControllerResource.new(controller, authorize: true)
       expect(resource.send(:resource_class)).to eq(Admin::Dashboard)
     end
 
     it 'does not build a single resource when on custom collection action even with id' do
-      params.merge!(:action => 'sort', :id => '123')
+      params.merge!(action: 'sort', id: '123')
 
-      resource = CanCan::ControllerResource.new(controller, :collection => [:sort, :list])
+      resource = CanCan::ControllerResource.new(controller, collection: [:sort, :list])
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to be_nil
     end
@@ -270,7 +270,7 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:find).with('1') { model }
 
-      params.merge!(:controller => 'categories', :model_id => 1)
+      params.merge!(controller: 'categories', model_id: 1)
       resource = CanCan::ControllerResource.new(controller, :model)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
@@ -279,14 +279,14 @@ describe CanCan::ControllerResource do
     it 'authorizes nested resource through parent association on index action' do
       controller.instance_variable_set(:@category, category = double)
       allow(controller).to receive(:authorize!).with(:index, category => Model) { raise CanCan::AccessDenied }
-      resource = CanCan::ControllerResource.new(controller, :through => :category)
+      resource = CanCan::ControllerResource.new(controller, through: :category)
       expect { resource.authorize_resource }.to raise_error(CanCan::AccessDenied)
     end
   end
 
   context 'on instance read actions' do
     before :each do
-      params.merge!(:action => 'show', :id => '123')
+      params.merge!(action: 'show', id: '123')
     end
 
     it 'loads the resource into an instance variable if params[:id] is specified' do
@@ -308,7 +308,7 @@ describe CanCan::ControllerResource do
     it 'loads resource for namespaced controller' do
       model = Model.new
       allow(Model).to receive(:find).with('123') { model }
-      params.merge!(:controller => 'admin/models')
+      params.merge!(controller: 'admin/models')
 
       resource = CanCan::ControllerResource.new(controller)
       resource.load_resource
@@ -337,28 +337,28 @@ describe CanCan::ControllerResource do
     end
 
     it 'loads resource through the association of another parent resource using instance variable' do
-      category = double(:models => {})
+      category = double(models: {})
       controller.instance_variable_set(:@category, category)
       allow(category.models).to receive(:find).with('123') { :some_model }
-      resource = CanCan::ControllerResource.new(controller, :through => :category)
+      resource = CanCan::ControllerResource.new(controller, through: :category)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(:some_model)
     end
 
     it 'loads resource through the custom association name' do
-      category = double(:custom_models => {})
+      category = double(custom_models: {})
       controller.instance_variable_set(:@category, category)
       allow(category.custom_models).to receive(:find).with('123') { :some_model }
-      resource = CanCan::ControllerResource.new(controller, :through => :category, :through_association => :custom_models)
+      resource = CanCan::ControllerResource.new(controller, through: :category, through_association: :custom_models)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(:some_model)
     end
 
     it 'loads resource through the association of another parent resource using method' do
-      category = double(:models => {})
+      category = double(models: {})
       allow(controller).to receive(:category) { category }
       allow(category.models).to receive(:find).with('123') { :some_model }
-      resource = CanCan::ControllerResource.new(controller, :through => :category)
+      resource = CanCan::ControllerResource.new(controller, through: :category)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(:some_model)
     end
@@ -367,13 +367,13 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:find).with('123') { model }
 
-      resource = CanCan::ControllerResource.new(controller, :through => :category, :shallow => true)
+      resource = CanCan::ControllerResource.new(controller, through: :category, shallow: true)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
 
     it 'raises AccessDenied when attempting to load resource through nil' do
-      resource = CanCan::ControllerResource.new(controller, :through => :category)
+      resource = CanCan::ControllerResource.new(controller, through: :category)
       expect {
         resource.load_resource
       }.to raise_error(CanCan::AccessDenied) { |exception|
@@ -384,27 +384,27 @@ describe CanCan::ControllerResource do
     end
 
     it 'loads through first matching if multiple are given' do
-      category = double(:models => {})
+      category = double(models: {})
       controller.instance_variable_set(:@category, category)
       allow(category.models).to receive(:find).with('123') { :some_model }
 
-      resource = CanCan::ControllerResource.new(controller, :through => [:category, :user])
+      resource = CanCan::ControllerResource.new(controller, through: [:category, :user])
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(:some_model)
     end
 
     it 'finds record through has_one association with :singleton option without id param' do
-      params.merge!(:id => nil)
+      params.merge!(id: nil)
 
-      category = double(:model => :some_model)
+      category = double(model: :some_model)
       controller.instance_variable_set(:@category, category)
-      resource = CanCan::ControllerResource.new(controller, :through => :category, :singleton => true)
+      resource = CanCan::ControllerResource.new(controller, through: :category, singleton: true)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(:some_model)
     end
 
     it 'does not try to load resource for other action if params[:id] is undefined' do
-      params.merge!(:action => 'list', :id => nil)
+      params.merge!(action: 'list', id: nil)
       resource = CanCan::ControllerResource.new(controller)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to be_nil
@@ -414,7 +414,7 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:find).with('123') { model }
 
-      resource = CanCan::ControllerResource.new(controller, :through => :category, :singleton => true, :shallow => true)
+      resource = CanCan::ControllerResource.new(controller, through: :category, singleton: true, shallow: true)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
@@ -423,7 +423,7 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:find).with('123') { model }
 
-      resource = CanCan::ControllerResource.new(controller, :class => Model)
+      resource = CanCan::ControllerResource.new(controller, class: Model)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
@@ -436,14 +436,14 @@ describe CanCan::ControllerResource do
       model = Sub::Model.new
       allow(Sub::Model).to receive(:find).with('123') { model }
 
-      resource = CanCan::ControllerResource.new(controller, :class => ::Sub::Model)
+      resource = CanCan::ControllerResource.new(controller, class: ::Sub::Model)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
 
     it 'authorizes based on resource name if class is false' do
       allow(controller).to receive(:authorize!).with(:show, :model) { raise CanCan::AccessDenied }
-      resource = CanCan::ControllerResource.new(controller, :class => false)
+      resource = CanCan::ControllerResource.new(controller, class: false)
       expect { resource.authorize_resource }.to raise_error(CanCan::AccessDenied)
     end
 
@@ -452,7 +452,7 @@ describe CanCan::ControllerResource do
       allow(Model).to receive(:find).with('123') { model }
 
       allow(controller).to receive(:authorize!).with(:show, model) { raise CanCan::AccessDenied }
-      resource = CanCan::ControllerResource.new(controller, :instance_name => :custom_model)
+      resource = CanCan::ControllerResource.new(controller, instance_name: :custom_model)
       expect { resource.load_and_authorize_resource }.to raise_error(CanCan::AccessDenied)
       expect(controller.instance_variable_get(:@custom_model)).to eq(model)
     end
@@ -461,22 +461,22 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:find).with('123') { model }
 
-      params.merge!(:the_model => 123)
-      resource = CanCan::ControllerResource.new(controller, :id_param => :the_model)
+      params.merge!(the_model: 123)
+      resource = CanCan::ControllerResource.new(controller, id_param: :the_model)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
 
     # CVE-2012-5664
     it 'always converts id param to string' do
-      params.merge!(:the_model => { :malicious => 'I am' })
-      resource = CanCan::ControllerResource.new(controller, :id_param => :the_model)
+      params.merge!(the_model: { malicious: 'I am' })
+      resource = CanCan::ControllerResource.new(controller, id_param: :the_model)
       expect(resource.send(:id_param).class).to eq(String)
     end
 
     it 'should id param return nil if param is nil' do
-      params.merge!(:the_model => nil)
-      resource = CanCan::ControllerResource.new(controller, :id_param => :the_model)
+      params.merge!(the_model: nil)
+      resource = CanCan::ControllerResource.new(controller, id_param: :the_model)
       expect(resource.send(:id_param)).to be_nil
     end
 
@@ -484,8 +484,8 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:name).with('foo') { model }
 
-      params.merge!(:action => 'show', :id => 'foo')
-      resource = CanCan::ControllerResource.new(controller, :find_by => :name)
+      params.merge!(action: 'show', id: 'foo')
+      resource = CanCan::ControllerResource.new(controller, find_by: :name)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
@@ -494,8 +494,8 @@ describe CanCan::ControllerResource do
       model = Model.new
       allow(Model).to receive(:find_by_name).with('foo') { model }
 
-      params.merge!(:action => 'show', :id => 'foo')
-      resource = CanCan::ControllerResource.new(controller, :find_by => :find_by_name)
+      params.merge!(action: 'show', id: 'foo')
+      resource = CanCan::ControllerResource.new(controller, find_by: :find_by_name)
       resource.load_resource
       expect(controller.instance_variable_get(:@model)).to eq(model)
     end
@@ -505,7 +505,7 @@ describe CanCan::ControllerResource do
     it 'returns namespaced #resource_class' do
       module Admin; end
       class Admin::Dashboard; end;
-      params.merge!(:controller => 'admin/dashboard')
+      params.merge!(controller: 'admin/dashboard')
       resource = CanCan::ControllerResource.new(controller, :dashboard)
 
       expect(resource.send(:resource_class)).to eq Admin::Dashboard
@@ -513,7 +513,7 @@ describe CanCan::ControllerResource do
   end
 
   it 'calls the santitizer when the parameter hash matches our object' do
-    params.merge!(:action => 'create', :model => { :name => 'test' })
+    params.merge!(action: 'create', model: { name: 'test' })
     allow(controller).to receive(:create_params).and_return({})
 
     resource = CanCan::ControllerResource.new(controller)
@@ -522,16 +522,16 @@ describe CanCan::ControllerResource do
   end
 
   it 'santitizes correctly when the instance name is overriden' do
-    params.merge!(:action => 'create', :custom_name => {:name => 'foobar'})
+    params.merge!(action: 'create', custom_name: {name: 'foobar'})
     allow(controller).to receive(:create_params).and_return({})
 
-    resource = CanCan::ControllerResource.new(controller, :instance_name => :custom_name)
+    resource = CanCan::ControllerResource.new(controller, instance_name: :custom_name)
     resource.load_resource
     expect(controller.instance_variable_get(:@custom_name).name).to eq nil
   end
 
   it 'calls the santitize method on non-save actions when required' do
-    params.merge!(:action => 'new', :model => { :name => 'test' })
+    params.merge!(action: 'new', model: { name: 'test' })
 
     allow(controller).to receive(:resource_params).and_return({})
     resource = CanCan::ControllerResource.new(controller)
@@ -540,7 +540,7 @@ describe CanCan::ControllerResource do
   end
 
   it "doesn't sanitize parameters on non-save actions when not required" do
-    params.merge!(:action => 'new', :not_our_model => { :name => 'test' })
+    params.merge!(action: 'new', not_our_model: { name: 'test' })
     allow(controller).to receive(:resource_params).and_raise
 
     resource = CanCan::ControllerResource.new(controller)
@@ -560,12 +560,12 @@ describe CanCan::ControllerResource do
   end
 
   it 'is parent if specified in options' do
-    resource = CanCan::ControllerResource.new(controller, :model, {:parent => true})
+    resource = CanCan::ControllerResource.new(controller, :model, {parent: true})
     expect(resource).to be_parent
   end
 
   it 'does not be parent if specified in options' do
-    resource = CanCan::ControllerResource.new(controller, :category, {:parent => false})
+    resource = CanCan::ControllerResource.new(controller, :category, {parent: false})
     expect(resource).to_not be_parent
   end
 
@@ -577,65 +577,65 @@ describe CanCan::ControllerResource do
 
   it 'raises ImplementationRemoved when adding :name option' do
     expect {
-      CanCan::ControllerResource.new(controller, :name => :foo)
+      CanCan::ControllerResource.new(controller, name: :foo)
     }.to raise_error(CanCan::ImplementationRemoved)
   end
 
   it 'raises ImplementationRemoved exception when specifying :resource option since it is no longer used' do
     expect {
-      CanCan::ControllerResource.new(controller, :resource => Model)
+      CanCan::ControllerResource.new(controller, resource: Model)
     }.to raise_error(CanCan::ImplementationRemoved)
   end
 
   it 'raises ImplementationRemoved exception when passing :nested option' do
     expect {
-      CanCan::ControllerResource.new(controller, :nested => :model)
+      CanCan::ControllerResource.new(controller, nested: :model)
     }.to raise_error(CanCan::ImplementationRemoved)
   end
 
   it 'skips resource behavior for :only actions in array' do
-    allow(controller_class).to receive(:cancan_skipper) { {:load => {nil => {:only => [:index, :show]}}} }
-    params.merge!(:action => 'index')
+    allow(controller_class).to receive(:cancan_skipper) { {load: {nil => {only: [:index, :show]}}} }
+    params.merge!(action: 'index')
     expect(CanCan::ControllerResource.new(controller).skip?(:load)).to be(true)
     expect(CanCan::ControllerResource.new(controller, :some_resource).skip?(:load)).to be(false)
-    params.merge!(:action => 'show')
+    params.merge!(action: 'show')
     expect(CanCan::ControllerResource.new(controller).skip?(:load)).to be(true)
-    params.merge!(:action => 'other_action')
+    params.merge!(action: 'other_action')
     expect(CanCan::ControllerResource.new(controller).skip?(:load)).to be_falsey
   end
 
   it 'skips resource behavior for :only one action on resource' do
-    allow(controller_class).to receive(:cancan_skipper) { {:authorize => {:model => {:only => :index}}} }
-    params.merge!(:action => 'index')
+    allow(controller_class).to receive(:cancan_skipper) { {authorize: {model: {only: :index}}} }
+    params.merge!(action: 'index')
     expect(CanCan::ControllerResource.new(controller).skip?(:authorize)).to be(false)
     expect(CanCan::ControllerResource.new(controller, :model).skip?(:authorize)).to be(true)
-    params.merge!(:action => 'other_action')
+    params.merge!(action: 'other_action')
     expect(CanCan::ControllerResource.new(controller, :model).skip?(:authorize)).to be_falsey
   end
 
   it 'skips resource behavior :except actions in array' do
-    allow(controller_class).to receive(:cancan_skipper) { {:load => {nil => {:except => [:index, :show]}}} }
-    params.merge!(:action => 'index')
+    allow(controller_class).to receive(:cancan_skipper) { {load: {nil => {except: [:index, :show]}}} }
+    params.merge!(action: 'index')
     expect(CanCan::ControllerResource.new(controller).skip?(:load)).to be_falsey
-    params.merge!(:action => 'show')
+    params.merge!(action: 'show')
     expect(CanCan::ControllerResource.new(controller).skip?(:load)).to be_falsey
-    params.merge!(:action => 'other_action')
+    params.merge!(action: 'other_action')
     expect(CanCan::ControllerResource.new(controller).skip?(:load)).to be(true)
     expect(CanCan::ControllerResource.new(controller, :some_resource).skip?(:load)).to be(false)
   end
 
   it 'skips resource behavior :except one action on resource' do
-    allow(controller_class).to receive(:cancan_skipper) { {:authorize => {:model => {:except => :index}}} }
-    params.merge!(:action => 'index')
+    allow(controller_class).to receive(:cancan_skipper) { {authorize: {model: {except: :index}}} }
+    params.merge!(action: 'index')
     expect(CanCan::ControllerResource.new(controller, :model).skip?(:authorize)).to be_falsey
-    params.merge!(:action => 'other_action')
+    params.merge!(action: 'other_action')
     expect(CanCan::ControllerResource.new(controller).skip?(:authorize)).to be(false)
     expect(CanCan::ControllerResource.new(controller, :model).skip?(:authorize)).to be(true)
   end
 
   it 'skips loading and authorization' do
-    allow(controller_class).to receive(:cancan_skipper) { {:authorize => {nil => {}}, :load => {nil => {}}} }
-    params.merge!(:action => 'new')
+    allow(controller_class).to receive(:cancan_skipper) { {authorize: {nil => {}}, load: {nil => {}}} }
+    params.merge!(action: 'new')
     resource = CanCan::ControllerResource.new(controller)
     expect { resource.load_and_authorize_resource }.not_to raise_error
     expect(controller.instance_variable_get(:@model)).to be_nil

--- a/spec/cancan/exceptions_spec.rb
+++ b/spec/cancan/exceptions_spec.rb
@@ -39,7 +39,7 @@ describe CanCan::AccessDenied do
     end
 
     it 'uses i18n for the default message' do
-      I18n.backend.store_translations :en, :unauthorized => {:default => 'This is a different message'}
+      I18n.backend.store_translations :en, unauthorized: {default: 'This is a different message'}
       @exception = CanCan::AccessDenied.new
       expect(@exception.message).to eq('This is a different message')
     end

--- a/spec/cancan/inherited_resource_spec.rb
+++ b/spec/cancan/inherited_resource_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe CanCan::InheritedResource do
   let(:ability) { Ability.new(nil) }
-  let(:params) { HashWithIndifferentAccess.new(:controller => 'models') }
+  let(:params) { HashWithIndifferentAccess.new(controller: 'models') }
   let(:controller_class) { Class.new }
   let(:controller) { controller_class.new }
 
@@ -19,11 +19,11 @@ describe CanCan::InheritedResource do
 
     allow(controller).to receive(:params) { params }
     allow(controller).to receive(:current_ability) { ability }
-    allow(controller_class).to receive(:cancan_skipper) { {:authorize => {}, :load => {}} }
+    allow(controller_class).to receive(:cancan_skipper) { {authorize: {}, load: {}} }
   end
 
   it 'show loads resource through controller.resource' do
-    params.merge!(:action => 'show', :id => 123)
+    params.merge!(action: 'show', id: 123)
     allow(controller).to receive(:resource) { :model_resource }
     CanCan::InheritedResource.new(controller).load_resource
     expect(controller.instance_variable_get(:@model)).to eq(:model_resource)
@@ -39,7 +39,7 @@ describe CanCan::InheritedResource do
   it 'index loads through controller.association_chain when parent' do
     params[:action] = 'index'
     allow(controller).to receive(:association_chain) { controller.instance_variable_set(:@model, :model_resource) }
-    CanCan::InheritedResource.new(controller, :parent => true).load_resource
+    CanCan::InheritedResource.new(controller, parent: true).load_resource
     expect(controller.instance_variable_get(:@model)).to eq(:model_resource)
   end
 
@@ -53,7 +53,7 @@ describe CanCan::InheritedResource do
 
   it 'builds a new resource with attributes from current ability' do
     params[:action] = 'new'
-    ability.can(:create, Model, :name => 'from conditions')
+    ability.can(:create, Model, name: 'from conditions')
     allow(controller).to receive(:build_resource) { Struct.new(:name).new }
     resource = CanCan::InheritedResource.new(controller)
     resource.load_resource
@@ -61,8 +61,8 @@ describe CanCan::InheritedResource do
   end
 
   it 'overrides initial attributes with params' do
-    params.merge!(:action => 'new', :model => {:name => 'from params'})
-    ability.can(:create, Model, :name => 'from conditions')
+    params.merge!(action: 'new', model: {name: 'from params'})
+    ability.can(:create, Model, name: 'from conditions')
     allow(controller).to receive(:build_resource) { Struct.new(:name).new }
     resource = CanCan::ControllerResource.new(controller)
     resource.load_resource

--- a/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_4_adapter_spec.rb
@@ -4,21 +4,21 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
   describe CanCan::ModelAdapters::ActiveRecord4Adapter do
     context 'with sqlite3' do
       before :each do
-        ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
+        ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Schema.define do
           create_table(:parents) do |t|
-            t.timestamps :null => false
+            t.timestamps null: false
           end
 
           create_table(:children) do |t|
-            t.timestamps :null => false
+            t.timestamps null: false
             t.integer :parent_id
           end
         end
 
         class Parent < ActiveRecord::Base
-          has_many :children, lambda { order(:id => :desc) }
+          has_many :children, lambda { order(id: :desc) }
         end
 
         class Child < ActiveRecord::Base
@@ -32,10 +32,10 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
         @ability.can :read, [Parent, Child]
 
         parent = Parent.create!
-        child1 = Child.create!(:parent => parent, :created_at => 1.hours.ago)
-        child2 = Child.create!(:parent => parent, :created_at => 2.hours.ago)
+        child1 = Child.create!(parent: parent, created_at: 1.hours.ago)
+        child2 = Child.create!(parent: parent, created_at: 2.hours.ago)
 
-        expect(Parent.accessible_by(@ability).order(:created_at => :asc).includes(:children).first.children).to eq [child2, child1]
+        expect(Parent.accessible_by(@ability).order(created_at: :asc).includes(:children).first.children).to eq [child2, child1]
       end
 
       if ActiveRecord::VERSION::MINOR >= 1
@@ -111,24 +111,24 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
     if Gem::Specification.find_all_by_name('pg').any?
       context 'with postgresql' do
         before :each do
-          ActiveRecord::Base.establish_connection(:adapter => 'postgresql', :database => 'postgres', :schema_search_path => 'public')
+          ActiveRecord::Base.establish_connection(adapter: 'postgresql', database: 'postgres', schema_search_path: 'public')
           ActiveRecord::Base.connection.drop_database('cancan_postgresql_spec')
           ActiveRecord::Base.connection.create_database 'cancan_postgresql_spec', 'encoding' => 'utf-8', 'adapter' => 'postgresql'
-          ActiveRecord::Base.establish_connection(:adapter => 'postgresql', :database => 'cancan_postgresql_spec')
+          ActiveRecord::Base.establish_connection(adapter: 'postgresql', database: 'cancan_postgresql_spec')
           ActiveRecord::Migration.verbose = false
           ActiveRecord::Schema.define do
             create_table(:parents) do |t|
-              t.timestamps :null => false
+              t.timestamps null: false
             end
 
             create_table(:children) do |t|
-              t.timestamps :null => false
+              t.timestamps null: false
               t.integer :parent_id
             end
           end
 
           class Parent < ActiveRecord::Base
-            has_many :children, lambda { order(:id => :desc) }
+            has_many :children, lambda { order(id: :desc) }
           end
 
           class Child < ActiveRecord::Base
@@ -139,12 +139,12 @@ if defined? CanCan::ModelAdapters::ActiveRecord4Adapter
         end
 
         it 'allows overlapping conditions in SQL and merge with hash conditions' do
-          @ability.can :read, Parent, :children => {:parent_id => 1}
-          @ability.can :read, Parent, :children => {:parent_id => 1}
+          @ability.can :read, Parent, children: {parent_id: 1}
+          @ability.can :read, Parent, children: {parent_id: 1}
 
           parent = Parent.create!
-          child1 = Child.create!(:parent => parent, :created_at => 1.hours.ago)
-          child2 = Child.create!(:parent => parent, :created_at => 2.hours.ago)
+          child1 = Child.create!(parent: parent, created_at: 1.hours.ago)
+          child2 = Child.create!(parent: parent, created_at: 2.hours.ago)
 
           expect(Parent.accessible_by(@ability)).to eq([parent])
         end

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -5,23 +5,23 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
   describe CanCan::ModelAdapters::ActiveRecordAdapter do
 
     before :each do
-      ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
+      ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
       ActiveRecord::Migration.verbose = false
       ActiveRecord::Schema.define do
         create_table(:categories) do |t|
           t.string :name
           t.boolean :visible
-          t.timestamps :null => false
+          t.timestamps null: false
         end
 
         create_table(:projects) do |t|
           t.string :name
-          t.timestamps :null => false
+          t.timestamps null: false
         end
 
         create_table(:articles) do |t|
           t.string :name
-          t.timestamps :null => false
+          t.timestamps null: false
           t.boolean :published
           t.boolean :secret
           t.integer :priority
@@ -32,17 +32,17 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
         create_table(:comments) do |t|
           t.boolean :spam
           t.integer :article_id
-          t.timestamps :null => false
+          t.timestamps null: false
         end
 
         create_table(:legacy_mentions) do |t|
           t.integer :user_id
           t.integer :article_id
-          t.timestamps :null => false
+          t.timestamps null: false
         end
 
         create_table(:users) do |t|
-          t.timestamps :null => false
+          t.timestamps null: false
         end
       end
 
@@ -57,7 +57,7 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
         belongs_to :category
         has_many :comments
         has_many :mentions
-        has_many :mentioned_users, :through => :mentions, :source => :user
+        has_many :mentioned_users, through: :mentions, source: :user
         belongs_to :user
       end
 
@@ -111,19 +111,19 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
     end
 
     it 'fetches only the articles that are published' do
-      @ability.can :read, Article, :published => true
-      article1 = Article.create!(:published => true)
-      article2 = Article.create!(:published => false)
+      @ability.can :read, Article, published: true
+      article1 = Article.create!(published: true)
+      article2 = Article.create!(published: false)
       expect(Article.accessible_by(@ability)).to eq([article1])
     end
 
     it 'fetches any articles which are published or secret' do
-      @ability.can :read, Article, :published => true
-      @ability.can :read, Article, :secret => true
-      article1 = Article.create!(:published => true, :secret => false)
-      article2 = Article.create!(:published => true, :secret => true)
-      article3 = Article.create!(:published => false, :secret => true)
-      article4 = Article.create!(:published => false, :secret => false)
+      @ability.can :read, Article, published: true
+      @ability.can :read, Article, secret: true
+      article1 = Article.create!(published: true, secret: false)
+      article2 = Article.create!(published: true, secret: true)
+      article3 = Article.create!(published: false, secret: true)
+      article4 = Article.create!(published: false, secret: false)
       expect(Article.accessible_by(@ability)).to eq([article1, article2, article3])
     end
 
@@ -132,82 +132,82 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
       cited = Article.create!
       not_cited = Article.create!
       cited.mentioned_users << user
-      @ability.can :read, Article, { :mentioned_users => { :id => user.id } }
-      @ability.can :read, Article, { :mentions => { :user_id => user.id } }
+      @ability.can :read, Article, { mentioned_users: { id: user.id } }
+      @ability.can :read, Article, { mentions: { user_id: user.id } }
       expect(Article.accessible_by(@ability)).to eq([cited])
     end
 
     it 'fetches only the articles that are published and not secret' do
-      @ability.can :read, Article, :published => true
-      @ability.cannot :read, Article, :secret => true
-      article1 = Article.create!(:published => true, :secret => false)
-      article2 = Article.create!(:published => true, :secret => true)
-      article3 = Article.create!(:published => false, :secret => true)
-      article4 = Article.create!(:published => false, :secret => false)
+      @ability.can :read, Article, published: true
+      @ability.cannot :read, Article, secret: true
+      article1 = Article.create!(published: true, secret: false)
+      article2 = Article.create!(published: true, secret: true)
+      article3 = Article.create!(published: false, secret: true)
+      article4 = Article.create!(published: false, secret: false)
       expect(Article.accessible_by(@ability)).to eq([article1])
     end
 
     it 'only reads comments for articles which are published' do
-      @ability.can :read, Comment, :article => { :published => true }
-      comment1 = Comment.create!(:article => Article.create!(:published => true))
-      comment2 = Comment.create!(:article => Article.create!(:published => false))
+      @ability.can :read, Comment, article: { published: true }
+      comment1 = Comment.create!(article: Article.create!(published: true))
+      comment2 = Comment.create!(article: Article.create!(published: false))
       expect(Comment.accessible_by(@ability)).to eq([comment1])
     end
 
     it 'should only read articles which are published or in visible categories' do
-      @ability.can :read, Article, :category => { :visible => true }
-      @ability.can :read, Article, :published => true
-      article1 = Article.create!(:published => true)
-      article2 = Article.create!(:published => false)
-      article3 = Article.create!(:published => false, :category => Category.create!(:visible => true))
+      @ability.can :read, Article, category: { visible: true }
+      @ability.can :read, Article, published: true
+      article1 = Article.create!(published: true)
+      article2 = Article.create!(published: false)
+      article3 = Article.create!(published: false, category: Category.create!(visible: true))
       expect(Article.accessible_by(@ability)).to eq([article1, article3])
     end
 
     it 'should only read categories once even if they have multiple articles' do
-      @ability.can :read, Category, :articles => { :published => true }
-      @ability.can :read, Article, :published => true
+      @ability.can :read, Category, articles: { published: true }
+      @ability.can :read, Article, published: true
       category = Category.create!
-      Article.create!(:published => true, :category => category)
-      Article.create!(:published => true, :category => category)
+      Article.create!(published: true, category: category)
+      Article.create!(published: true, category: category)
       expect(Category.accessible_by(@ability)).to eq([category])
     end
 
     it 'only reads comments for visible categories through articles' do
-      @ability.can :read, Comment, :article => { :category => { :visible => true } }
-      comment1 = Comment.create!(:article => Article.create!(:category => Category.create!(:visible => true)))
-      comment2 = Comment.create!(:article => Article.create!(:category => Category.create!(:visible => false)))
+      @ability.can :read, Comment, article: { category: { visible: true } }
+      comment1 = Comment.create!(article: Article.create!(category: Category.create!(visible: true)))
+      comment2 = Comment.create!(article: Article.create!(category: Category.create!(visible: false)))
       expect(Comment.accessible_by(@ability)).to eq([comment1])
     end
 
     it 'allows conditions in SQL and merge with hash conditions' do
-      @ability.can :read, Article, :published => true
+      @ability.can :read, Article, published: true
       @ability.can :read, Article, ['secret=?', true]
-      article1 = Article.create!(:published => true, :secret => false)
-      article2 = Article.create!(:published => true, :secret => true)
-      article3 = Article.create!(:published => false, :secret => true)
-      article4 = Article.create!(:published => false, :secret => false)
+      article1 = Article.create!(published: true, secret: false)
+      article2 = Article.create!(published: true, secret: true)
+      article3 = Article.create!(published: false, secret: true)
+      article4 = Article.create!(published: false, secret: false)
       expect(Article.accessible_by(@ability)).to eq([article1, article2, article3])
     end
 
     it 'allows a scope for conditions' do
-      @ability.can :read, Article, Article.where(:secret => true)
-      article1 = Article.create!(:secret => true)
-      article2 = Article.create!(:secret => false)
+      @ability.can :read, Article, Article.where(secret: true)
+      article1 = Article.create!(secret: true)
+      article2 = Article.create!(secret: false)
       expect(Article.accessible_by(@ability)).to eq([article1])
     end
 
     it 'fetches only associated records when using with a scope for conditions' do
-      @ability.can :read, Article, Article.where(:secret => true)
-      category1 = Category.create!(:visible => false)
-      category2 = Category.create!(:visible => true)
-      article1 = Article.create!(:secret => true, :category => category1)
-      article2 = Article.create!(:secret => true, :category => category2)
+      @ability.can :read, Article, Article.where(secret: true)
+      category1 = Category.create!(visible: false)
+      category2 = Category.create!(visible: true)
+      article1 = Article.create!(secret: true, category: category1)
+      article2 = Article.create!(secret: true, category: category2)
       expect(category1.articles.accessible_by(@ability)).to eq([article1])
     end
 
     it 'raises an exception when trying to merge scope with other conditions' do
-      @ability.can :read, Article, :published => true
-      @ability.can :read, Article, Article.where(:secret => true)
+      @ability.can :read, Article, published: true
+      @ability.can :read, Article, Article.where(secret: true)
       expect(lambda { Article.accessible_by(@ability) }).to raise_error(CanCan::Error, 'Unable to merge an Active Record scope with other conditions. Instead use a hash or SQL for read Article ability.')
     end
 
@@ -219,9 +219,9 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
     end
 
     it 'should support more than one deeply nested conditions' do
-      @ability.can :read, Comment, :article => {
-        :category => {
-          :name => 'foo', :visible => true
+      @ability.can :read, Comment, article: {
+        category: {
+          name: 'foo', visible: true
         }
       }
       expect { Comment.accessible_by(@ability) }.to_not raise_error
@@ -243,50 +243,50 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
 
     it 'returns SQL for single `can` definition in front of default `cannot` condition' do
       @ability.cannot :read, Article
-      @ability.can :read, Article, :published => false, :secret => true
+      @ability.can :read, Article, published: false, secret: true
       expect(@ability.model_adapter(Article, :read).conditions).to orderlessly_match(%Q["#{@article_table}"."published" = 'f' AND "#{@article_table}"."secret" = 't'])
     end
 
     it 'returns true condition for single `can` definition in front of default `can` condition' do
       @ability.can :read, Article
-      @ability.can :read, Article, :published => false, :secret => true
+      @ability.can :read, Article, published: false, secret: true
       expect(@ability.model_adapter(Article, :read).conditions).to eq("'t'='t'")
     end
 
     it 'returns `false condition` for single `cannot` definition in front of default `cannot` condition' do
       @ability.cannot :read, Article
-      @ability.cannot :read, Article, :published => false, :secret => true
+      @ability.cannot :read, Article, published: false, secret: true
       expect(@ability.model_adapter(Article, :read).conditions).to eq("'t'='f'")
     end
 
     it 'returns `not (sql)` for single `cannot` definition in front of default `can` condition' do
       @ability.can :read, Article
-      @ability.cannot :read, Article, :published => false, :secret => true
+      @ability.cannot :read, Article, published: false, secret: true
       expect(@ability.model_adapter(Article, :read).conditions).to orderlessly_match(%Q["not (#{@article_table}"."published" = 'f' AND "#{@article_table}"."secret" = 't')])
     end
 
     it 'returns appropriate sql conditions in complex case' do
       @ability.can :read, Article
-      @ability.can :manage, Article, :id => 1
-      @ability.can :update, Article, :published => true
-      @ability.cannot :update, Article, :secret => true
+      @ability.can :manage, Article, id: 1
+      @ability.can :update, Article, published: true
+      @ability.cannot :update, Article, secret: true
       expect(@ability.model_adapter(Article, :update).conditions).to eq(%Q[not ("#{@article_table}"."secret" = 't') AND (("#{@article_table}"."published" = 't') OR ("#{@article_table}"."id" = 1))])
-      expect(@ability.model_adapter(Article, :manage).conditions).to eq({:id => 1})
+      expect(@ability.model_adapter(Article, :manage).conditions).to eq({id: 1})
       expect(@ability.model_adapter(Article, :read).conditions).to eq("'t'='t'")
     end
 
     it 'returns appropriate sql conditions in complex case with nested joins' do
-      @ability.can :read, Comment, :article => { :category => { :visible => true } }
-      expect(@ability.model_adapter(Comment, :read).conditions).to eq({ Category.table_name.to_sym => { :visible => true } })
+      @ability.can :read, Comment, article: { category: { visible: true } }
+      expect(@ability.model_adapter(Comment, :read).conditions).to eq({ Category.table_name.to_sym => { visible: true } })
     end
 
     it 'returns appropriate sql conditions in complex case with nested joins of different depth' do
-      @ability.can :read, Comment, :article => { :published => true, :category => { :visible => true } }
-      expect(@ability.model_adapter(Comment, :read).conditions).to eq({ Article.table_name.to_sym => { :published => true }, Category.table_name.to_sym => { :visible => true } })
+      @ability.can :read, Comment, article: { published: true, category: { visible: true } }
+      expect(@ability.model_adapter(Comment, :read).conditions).to eq({ Article.table_name.to_sym => { published: true }, Category.table_name.to_sym => { visible: true } })
     end
 
     it 'does not forget conditions when calling with SQL string' do
-      @ability.can :read, Article, :published => true
+      @ability.can :read, Article, published: true
       @ability.can :read, Article, ['secret=?', false]
       adapter = @ability.model_adapter(Article, :read)
       2.times do
@@ -299,40 +299,40 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
     end
 
     it 'has nil joins if no nested hashes specified in conditions' do
-      @ability.can :read, Article, :published => false
-      @ability.can :read, Article, :secret => true
+      @ability.can :read, Article, published: false
+      @ability.can :read, Article, secret: true
       expect(@ability.model_adapter(Article, :read).joins).to be_nil
     end
 
     it 'merges separate joins into a single array' do
-      @ability.can :read, Article, :project => { :blocked => false }
-      @ability.can :read, Article, :company => { :admin => true }
+      @ability.can :read, Article, project: { blocked: false }
+      @ability.can :read, Article, company: { admin: true }
       expect(@ability.model_adapter(Article, :read).joins.inspect).to orderlessly_match([:company, :project].inspect)
     end
 
     it 'merges same joins into a single array' do
-      @ability.can :read, Article, :project => { :blocked => false }
-      @ability.can :read, Article, :project => { :admin => true }
+      @ability.can :read, Article, project: { blocked: false }
+      @ability.can :read, Article, project: { admin: true }
       expect(@ability.model_adapter(Article, :read).joins).to eq([:project])
     end
 
     it 'merges nested and non-nested joins' do
-      @ability.can :read, Article, :project => { :blocked => false }
-      @ability.can :read, Article, :project => { :comments => { :spam => true } }
-      expect(@ability.model_adapter(Article, :read).joins).to eq([{:project=>[:comments]}])
+      @ability.can :read, Article, project: { blocked: false }
+      @ability.can :read, Article, project: { comments: { spam: true } }
+      expect(@ability.model_adapter(Article, :read).joins).to eq([{project: [:comments]}])
     end
 
     it 'merges :all conditions with other conditions' do
       user = User.create!
-      article = Article.create!(:user => user)
+      article = Article.create!(user: user)
       ability = Ability.new(user)
       ability.can :manage, :all
-      ability.can :manage, Article, :user_id => user.id
+      ability.can :manage, Article, user_id: user.id
       expect(Article.accessible_by(ability)).to eq([article])
     end
 
     it 'should not execute a scope when checking ability on the class' do
-      relation = Article.where(:secret => true)
+      relation = Article.where(secret: true)
       @ability.can :read, Article, relation do |article|
         article.secret == true
       end
@@ -346,13 +346,13 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
       before :each do
         ActiveRecord::Schema.define do
           create_table( :table_xes ) do |t|
-            t.timestamps :null => false
+            t.timestamps null: false
           end
 
           create_table( :table_zs ) do |t|
             t.integer :table_x_id
             t.integer :user_id
-            t.timestamps :null => false
+            t.timestamps null: false
           end
         end
 
@@ -373,10 +373,10 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
         user = User.create!
 
         ability = Ability.new(user)
-        ability.can :read, Namespace::TableX, :table_zs => { :user_id => user.id }
+        ability.can :read, Namespace::TableX, table_zs: { user_id: user.id }
 
         table_x = Namespace::TableX.create!
-        table_z = table_x.table_zs.create( :user => user )
+        table_z = table_x.table_zs.create( user: user )
         expect(Namespace::TableX.accessible_by(ability)).to eq([table_x])
       end
     end
@@ -394,9 +394,9 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
       end
 
       it 'fetches only the valid records' do
-        @ability.can :read, Course, :start_at => 1.day.ago..1.day.from_now
-        Course.create!(:start_at => 10.days.ago)
-        valid_course = Course.create!(:start_at => Time.now)
+        @ability.can :read, Course, start_at: 1.day.ago..1.day.from_now
+        Course.create!(start_at: 10.days.ago)
+        valid_course = Course.create!(start_at: Time.now)
 
         expect(Course.accessible_by(@ability)).to eq([valid_course])
       end

--- a/spec/cancan/model_adapters/mongoid_adapter_spec.rb
+++ b/spec/cancan/model_adapters/mongoid_adapter_spec.rb
@@ -50,123 +50,123 @@ if defined? CanCan::ModelAdapters::MongoidAdapter
 
       it 'compares properties on mongoid documents with the conditions hash' do
         model = MongoidProject.new
-        @ability.can :read, MongoidProject, :id => model.id
+        @ability.can :read, MongoidProject, id: model.id
         expect(@ability).to be_able_to(:read, model)
       end
 
       it 'is able to read hashes when field is array' do
-        one_to_three = MongoidProject.create(:numbers => ['one', 'two', 'three'])
-        two_to_five  = MongoidProject.create(:numbers => ['two', 'three', 'four', 'five'])
+        one_to_three = MongoidProject.create(numbers: ['one', 'two', 'three'])
+        two_to_five  = MongoidProject.create(numbers: ['two', 'three', 'four', 'five'])
 
-        @ability.can :foo, MongoidProject, :numbers => 'one'
+        @ability.can :foo, MongoidProject, numbers: 'one'
         expect(@ability).to be_able_to(:foo, one_to_three)
         expect(@ability).not_to be_able_to(:foo, two_to_five)
       end
 
       it 'returns [] when no ability is defined so no records are found' do
-        MongoidProject.create(:title => 'Sir')
-        MongoidProject.create(:title => 'Lord')
-        MongoidProject.create(:title => 'Dude')
+        MongoidProject.create(title: 'Sir')
+        MongoidProject.create(title: 'Lord')
+        MongoidProject.create(title: 'Dude')
 
         expect(MongoidProject.accessible_by(@ability, :read).entries).to eq([])
       end
 
       it 'returns the correct records based on the defined ability' do
-        @ability.can :read, MongoidProject, :title => 'Sir'
-        sir   = MongoidProject.create(:title => 'Sir')
-        lord  = MongoidProject.create(:title => 'Lord')
-        dude  = MongoidProject.create(:title => 'Dude')
+        @ability.can :read, MongoidProject, title: 'Sir'
+        sir   = MongoidProject.create(title: 'Sir')
+        lord  = MongoidProject.create(title: 'Lord')
+        dude  = MongoidProject.create(title: 'Dude')
 
         expect(MongoidProject.accessible_by(@ability, :read).entries).to eq([sir])
       end
 
       it 'returns the correct records when a mix of can and cannot rules in defined ability' do
-        @ability.can :manage, MongoidProject, :title => 'Sir'
+        @ability.can :manage, MongoidProject, title: 'Sir'
         @ability.cannot :destroy, MongoidProject
 
-        sir   = MongoidProject.create(:title => 'Sir')
-        lord  = MongoidProject.create(:title => 'Lord')
-        dude  = MongoidProject.create(:title => 'Dude')
+        sir   = MongoidProject.create(title: 'Sir')
+        lord  = MongoidProject.create(title: 'Lord')
+        dude  = MongoidProject.create(title: 'Dude')
 
         expect(MongoidProject.accessible_by(@ability, :destroy).entries).to eq([sir])
       end
 
       it 'is able to mix empty conditions and hashes' do
         @ability.can :read, MongoidProject
-        @ability.can :read, MongoidProject, :title => 'Sir'
-        sir  = MongoidProject.create(:title => 'Sir')
-        lord = MongoidProject.create(:title => 'Lord')
+        @ability.can :read, MongoidProject, title: 'Sir'
+        sir  = MongoidProject.create(title: 'Sir')
+        lord = MongoidProject.create(title: 'Lord')
 
         expect(MongoidProject.accessible_by(@ability, :read).count).to eq(2)
       end
 
       it 'returns everything when the defined ability is access all' do
         @ability.can :manage, :all
-        sir   = MongoidProject.create(:title => 'Sir')
-        lord  = MongoidProject.create(:title => 'Lord')
-        dude  = MongoidProject.create(:title => 'Dude')
+        sir   = MongoidProject.create(title: 'Sir')
+        lord  = MongoidProject.create(title: 'Lord')
+        dude  = MongoidProject.create(title: 'Dude')
 
         expect(MongoidProject.accessible_by(@ability, :read).entries).to eq([sir, lord, dude])
       end
 
       it 'allows a scope for conditions' do
-        @ability.can :read, MongoidProject, MongoidProject.where(:title => 'Sir')
-        sir   = MongoidProject.create(:title => 'Sir')
-        lord  = MongoidProject.create(:title => 'Lord')
-        dude  = MongoidProject.create(:title => 'Dude')
+        @ability.can :read, MongoidProject, MongoidProject.where(title: 'Sir')
+        sir   = MongoidProject.create(title: 'Sir')
+        lord  = MongoidProject.create(title: 'Lord')
+        dude  = MongoidProject.create(title: 'Dude')
 
         expect(MongoidProject.accessible_by(@ability, :read).entries).to eq([sir])
       end
 
       describe 'Mongoid::Criteria where clause Symbol extensions using MongoDB expressions' do
         it 'handles :field.in' do
-          obj = MongoidProject.create(:title => 'Sir')
+          obj = MongoidProject.create(title: 'Sir')
           @ability.can :read, MongoidProject, :title.in => ['Sir', 'Madam']
           expect(@ability.can?(:read, obj)).to eq(true)
           expect(MongoidProject.accessible_by(@ability, :read)).to eq([obj])
 
-          obj2 = MongoidProject.create(:title => 'Lord')
+          obj2 = MongoidProject.create(title: 'Lord')
           expect(@ability.can?(:read, obj2)).to be(false)
         end
 
         describe 'activates only when there are Criteria in the hash' do
           it 'Calls where on the model class when there are criteria' do
-            obj = MongoidProject.create(:title => 'Bird')
+            obj = MongoidProject.create(title: 'Bird')
             @conditions = {:title.nin => ['Fork', 'Spoon']}
 
             @ability.can :read, MongoidProject, @conditions
             expect(@ability).to be_able_to(:read, obj)
           end
           it 'Calls the base version if there are no mongoid criteria' do
-            obj = MongoidProject.new(:title => 'Bird')
-            @conditions = {:id => obj.id}
+            obj = MongoidProject.new(title: 'Bird')
+            @conditions = {id: obj.id}
             @ability.can :read, MongoidProject, @conditions
             expect(@ability).to be_able_to(:read, obj)
           end
         end
 
         it 'handles :field.nin' do
-          obj = MongoidProject.create(:title => 'Sir')
+          obj = MongoidProject.create(title: 'Sir')
           @ability.can :read, MongoidProject, :title.nin => ['Lord', 'Madam']
           expect(@ability.can?(:read, obj)).to eq(true)
           expect(MongoidProject.accessible_by(@ability, :read)).to eq([obj])
 
-          obj2 = MongoidProject.create(:title => 'Lord')
+          obj2 = MongoidProject.create(title: 'Lord')
           expect(@ability.can?(:read, obj2)).to be(false)
         end
 
         it 'handles :field.size' do
-          obj = MongoidProject.create(:titles => ['Palatin', 'Margrave'])
+          obj = MongoidProject.create(titles: ['Palatin', 'Margrave'])
           @ability.can :read, MongoidProject, :titles.size => 2
           expect(@ability.can?(:read, obj)).to eq(true)
           expect(MongoidProject.accessible_by(@ability, :read)).to eq([obj])
 
-          obj2 = MongoidProject.create(:titles => ['Palatin', 'Margrave', 'Marquis'])
+          obj2 = MongoidProject.create(titles: ['Palatin', 'Margrave', 'Marquis'])
           expect(@ability.can?(:read, obj2)).to be(false)
         end
 
         it 'handles :field.exists' do
-          obj = MongoidProject.create(:titles => ['Palatin', 'Margrave'])
+          obj = MongoidProject.create(titles: ['Palatin', 'Margrave'])
           @ability.can :read, MongoidProject, :titles.exists => true
           expect(@ability.can?(:read, obj)).to eq(true)
           expect(MongoidProject.accessible_by(@ability, :read)).to eq([obj])
@@ -176,48 +176,48 @@ if defined? CanCan::ModelAdapters::MongoidAdapter
         end
 
         it 'handles :field.gt' do
-          obj = MongoidProject.create(:age => 50)
+          obj = MongoidProject.create(age: 50)
           @ability.can :read, MongoidProject, :age.gt => 45
           expect(@ability.can?(:read, obj)).to eq(true)
           expect(MongoidProject.accessible_by(@ability, :read)).to eq([obj])
 
-          obj2 = MongoidProject.create(:age => 40)
+          obj2 = MongoidProject.create(age: 40)
           expect(@ability.can?(:read, obj2)).to be(false)
         end
 
         it 'handles instance not saved to database' do
-          obj = MongoidProject.new(:title => 'Sir')
+          obj = MongoidProject.new(title: 'Sir')
           @ability.can :read, MongoidProject, :title.in => ['Sir', 'Madam']
           expect(@ability.can?(:read, obj)).to eq(true)
 
           # accessible_by only returns saved records
           expect(MongoidProject.accessible_by(@ability, :read).entries).to eq([])
 
-          obj2 = MongoidProject.new(:title => 'Lord')
+          obj2 = MongoidProject.new(title: 'Lord')
           expect(@ability.can?(:read, obj2)).to be(false)
         end
       end
 
       it 'calls where with matching ability conditions' do
-        obj = MongoidProject.create(:foo => {:bar => 1})
-        @ability.can :read, MongoidProject, :foo => {:bar => 1}
+        obj = MongoidProject.create(foo: {bar: 1})
+        @ability.can :read, MongoidProject, foo: {bar: 1}
         expect(MongoidProject.accessible_by(@ability, :read).entries.first).to eq(obj)
       end
 
       it 'excludes from the result if set to cannot' do
-        obj = MongoidProject.create(:bar => 1)
-        obj2 = MongoidProject.create(:bar => 2)
+        obj = MongoidProject.create(bar: 1)
+        obj2 = MongoidProject.create(bar: 2)
         @ability.can :read, MongoidProject
-        @ability.cannot :read, MongoidProject, :bar => 2
+        @ability.cannot :read, MongoidProject, bar: 2
         expect(MongoidProject.accessible_by(@ability, :read).entries).to eq([obj])
       end
 
       it 'combines the rules' do
-        obj = MongoidProject.create(:bar => 1)
-        obj2 = MongoidProject.create(:bar => 2)
-        obj3 = MongoidProject.create(:bar => 3)
-        @ability.can :read, MongoidProject, :bar => 1
-        @ability.can :read, MongoidProject, :bar => 2
+        obj = MongoidProject.create(bar: 1)
+        obj2 = MongoidProject.create(bar: 2)
+        obj3 = MongoidProject.create(bar: 3)
+        @ability.can :read, MongoidProject, bar: 1
+        @ability.can :read, MongoidProject, bar: 2
         expect(MongoidProject.accessible_by(@ability, :read).entries).to match_array([obj, obj2])
       end
 
@@ -231,7 +231,7 @@ if defined? CanCan::ModelAdapters::MongoidAdapter
       end
 
       it 'can handle nested queries for accessible_by' do
-        @ability.can :read, MongoidSubProject, {:mongoid_project => {:mongoid_category => { :name => 'Authorization'}}}
+        @ability.can :read, MongoidSubProject, {mongoid_project: {mongoid_category: { name: 'Authorization'}}}
         cat1 = MongoidCategory.create name: 'Authentication'
         cat2 = MongoidCategory.create name: 'Authorization'
         proj1 = cat1.mongoid_projects.create name: 'Proj1'

--- a/spec/cancan/model_adapters/sequel_adapter_spec.rb
+++ b/spec/cancan/model_adapters/sequel_adapter_spec.rb
@@ -72,60 +72,60 @@ if defined? CanCan::ModelAdapters::SequelAdapter
     end
 
     it 'should fetch only the articles that are published' do
-      @ability.can :read, Article, :published => true
-      article1 = Article.create(:published => true)
-      article2 = Article.create(:published => false)
+      @ability.can :read, Article, published: true
+      article1 = Article.create(published: true)
+      article2 = Article.create(published: false)
       expect(Article.accessible_by(@ability).all).to eq [article1]
     end
 
     it 'should fetch any articles which are published or secret' do
-      @ability.can :read, Article, :published => true
-      @ability.can :read, Article, :secret => true
-      article1 = Article.create(:published => true, :secret => false)
-      article2 = Article.create(:published => true, :secret => true)
-      article3 = Article.create(:published => false, :secret => true)
-      article4 = Article.create(:published => false, :secret => false)
+      @ability.can :read, Article, published: true
+      @ability.can :read, Article, secret: true
+      article1 = Article.create(published: true, secret: false)
+      article2 = Article.create(published: true, secret: true)
+      article3 = Article.create(published: false, secret: true)
+      article4 = Article.create(published: false, secret: false)
       expect(Article.accessible_by(@ability).all).to eq([article1, article2, article3])
     end
 
     it 'should fetch only the articles that are published and not secret' do
-      @ability.can :read, Article, :published => true
-      @ability.cannot :read, Article, :secret => true
-      article1 = Article.create(:published => true, :secret => false)
-      article2 = Article.create(:published => true, :secret => true)
-      article3 = Article.create(:published => false, :secret => true)
-      article4 = Article.create(:published => false, :secret => false)
+      @ability.can :read, Article, published: true
+      @ability.cannot :read, Article, secret: true
+      article1 = Article.create(published: true, secret: false)
+      article2 = Article.create(published: true, secret: true)
+      article3 = Article.create(published: false, secret: true)
+      article4 = Article.create(published: false, secret: false)
       expect(Article.accessible_by(@ability).all).to eq [article1]
     end
 
     it 'should only read comments for articles which are published' do
-      @ability.can :read, Comment, :article => { :published => true }
-      comment1 = Comment.create(:article => Article.create(:published => true))
-      comment2 = Comment.create(:article => Article.create(:published => false))
+      @ability.can :read, Comment, article: { published: true }
+      comment1 = Comment.create(article: Article.create(published: true))
+      comment2 = Comment.create(article: Article.create(published: false))
       expect(Comment.accessible_by(@ability).all).to eq [comment1]
     end
 
     it "should only read comments for articles which are published and user is 'me'" do
-      @ability.can :read, Comment, :article => { :user => { :name => 'me' }, :published => true }
-      user1 = User.create(:name => 'me')
-      comment1 = Comment.create(:article => Article.create(:published => true, :user => user1))
-      comment2 = Comment.create(:article => Article.create(:published => true))
-      comment3 = Comment.create(:article => Article.create(:published => false, :user => user1))
+      @ability.can :read, Comment, article: { user: { name: 'me' }, published: true }
+      user1 = User.create(name: 'me')
+      comment1 = Comment.create(article: Article.create(published: true, user: user1))
+      comment2 = Comment.create(article: Article.create(published: true))
+      comment3 = Comment.create(article: Article.create(published: false, user: user1))
       expect(Comment.accessible_by(@ability).all).to eq [comment1]
     end
 
     it 'should allow conditions in SQL and merge with hash conditions' do
-      @ability.can :read, Article, :published => true
+      @ability.can :read, Article, published: true
       @ability.can :read, Article, ['secret=?', true] do |article|
         article.secret
       end
       @ability.cannot :read, Article, 'priority > 1' do |article|
         article.priority > 1
       end
-      article1 = Article.create(:published => true, :secret => false, :priority => 1)
-      article2 = Article.create(:published => true, :secret => true, :priority => 1)
-      article3 = Article.create(:published => true, :secret => true, :priority => 2)
-      article4 = Article.create(:published => false, :secret => false, :priority => 2)
+      article1 = Article.create(published: true, secret: false, priority: 1)
+      article2 = Article.create(published: true, secret: true, priority: 1)
+      article3 = Article.create(published: true, secret: true, priority: 2)
+      article4 = Article.create(published: false, secret: false, priority: 2)
       expect(Article.accessible_by(@ability).all).to eq [article1, article2]
     end
   end

--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -18,19 +18,19 @@ describe CanCan::Rule do
   end
 
   it 'returns single association for joins' do
-    @conditions[:foo] = {:bar => 1}
-    expect(@rule.associations_hash).to eq({:foo => {}})
+    @conditions[:foo] = {bar: 1}
+    expect(@rule.associations_hash).to eq({foo: {}})
   end
 
   it 'returns multiple associations for joins' do
-    @conditions[:foo] = {:bar => 1}
+    @conditions[:foo] = {bar: 1}
     @conditions[:test] = {1 => 2}
-    expect(@rule.associations_hash).to eq({:foo => {}, :test => {}})
+    expect(@rule.associations_hash).to eq({foo: {}, test: {}})
   end
 
   it 'returns nested associations for joins' do
-    @conditions[:foo] = {:bar => {1 => 2}}
-    expect(@rule.associations_hash).to eq({:foo => {:bar => {}}})
+    @conditions[:foo] = {bar: {1 => 2}}
+    expect(@rule.associations_hash).to eq({foo: {bar: {}}})
   end
 
   it 'returns no association joins if conditions is nil' do
@@ -39,7 +39,7 @@ describe CanCan::Rule do
   end
 
   it 'is not mergeable if conditions are not simple hashes' do
-    meta_where = OpenStruct.new(:name => 'metawhere', :column => 'test')
+    meta_where = OpenStruct.new(name: 'metawhere', column: 'test')
     @conditions[meta_where] = :bar
 
     expect(@rule).to be_unmergeable

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ $:.unshift File.expand_path('../support', __FILE__)
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
-  config.filter_run :focus => true
+  config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.mock_with :rspec
   config.order = 'random'


### PR DESCRIPTION
Since cancancan requires ruby > 2.0 anyway we can drop old hash rocket syntax, use only the new syntax, and enabkle rubocop check