### PR TITLE
MongoidAdapter: Improves querying for finding relation_ids by replacing only->map with distinct

### DIFF
--- a/lib/cancan/model_adapters/mongoid_adapter.rb
+++ b/lib/cancan/model_adapters/mongoid_adapter.rb
@@ -62,7 +62,7 @@ module CanCan
             if (relation = model_relations[k])
               relation_class_name = relation[:class_name].blank? ? k.to_s.classify : relation[:class_name]
               v = simplify_relations(relation_class_name.constantize, v)
-              relation_ids = relation_class_name.constantize.where(v).only(:id).map(&:id)
+              relation_ids = relation_class_name.constantize.where(v).distinct(:_id)
               k = "#{k}_id"
               v = { '$in' => relation_ids }
             end


### PR DESCRIPTION
`distinct(:_id)` gives a significant performance boost over `only(:id).map(:id)`
I've also added a Benchmark for this.
```
1_000.times { FactoryGirl.create(:user) }
```
```
Benchmark.bmbm do |benchmark|
  benchmark.report("with_only_and_map") do
    User.only(:id).map(&:id)
  end
  benchmark.report("with_distinct") do
    User.distinct(:_id)
  end
end

```

```
user                system     total      real
with_only_and_map   0.020000   0.000000   0.020000 (  0.021605)
with_distinct       0.000000   0.000000   0.000000 (  0.012682)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cancancommunity/cancancan/398)
<!-- Reviewable:end -->
