### PR TITLE
fix rubocop version

### DIFF
--- a/gemfiles/activerecord_3.2.gemfile
+++ b/gemfiles/activerecord_3.2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 3.2.0", :require => "active_record"
 gem "actionpack", "~> 3.2.0", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_4.0.gemfile
+++ b/gemfiles/activerecord_4.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.0.5", :require => "active_record"
 gem "activesupport", "~> 4.0.5", :require => "active_support/all"
 gem "actionpack", "~> 4.0.5", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_4.1.gemfile
+++ b/gemfiles/activerecord_4.1.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.1.1", :require => "active_record"
 gem "activesupport", "~> 4.1.1", :require => "active_support/all"
 gem "actionpack", "~> 4.1.1", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_4.2.gemfile
+++ b/gemfiles/activerecord_4.2.gemfile
@@ -6,6 +6,7 @@ gem "activerecord", "~> 4.2.0", :require => "active_record"
 gem "activesupport", "~> 4.2.0", :require => "active_support/all"
 gem "actionpack", "~> 4.2.0", :require => "action_pack"
 gem "nokogiri", "~> 1.6.8", :require => "nokogiri"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 5.0.0.rc1", :require => "active_record"
 gem "activesupport", "~> 5.0.0.rc1", :require => "active_support/all"
 gem "actionpack", "~> 5.0.0.rc1", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/mongoid_2.x.gemfile
+++ b/gemfiles/mongoid_2.x.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activesupport", "~> 3.0", :require => "active_support/all"
 gem "actionpack", "~> 3.0", :require => "action_pack"
 gem "mongoid", "~> 2.0.0"
+gem "rubocop", "0.48.0"
 
 platforms :ruby, :mswin, :mingw do
   gem "bson_ext", "~> 1.1"

--- a/gemfiles/sequel_3.x.gemfile
+++ b/gemfiles/sequel_3.x.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "sequel", "~> 3.48.0"
 gem "activesupport", "~> 3.0", :require => "active_support/all"
 gem "actionpack", "~> 3.0", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "jdbc-sqlite3"


### PR DESCRIPTION
This PR fix the rubocop issue causing builds to fail when rubocop releases a new version