### PR TITLE
Backport "Use `ActiveSupport.on_load` hook to include `CanCan::ModelAdditions`"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,5 +34,6 @@ AllCops:
   TargetRubyVersion: 2.0
   Exclude:
     - 'gemfiles/vendor/bundle/**/*'
+    - 'Appraisals'
 
 inherit_from: .rubocop_todo.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,3 +46,9 @@ Style/PredicateName:
   Exclude:
     - 'spec/**/*'
     - 'lib/cancan/ability.rb'
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All permissions are defined in a single location (the `Ability` class) and not d
 
 Add this to your Gemfile: 
 
-    gem 'cancancan'
+    gem 'cancancan', '~> 1.10'
     
 and run the `bundle install` command.
 

--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cancan/version'

--- a/gemfiles/activerecord_3.2.gemfile
+++ b/gemfiles/activerecord_3.2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 3.2.0", :require => "active_record"
 gem "actionpack", "~> 3.2.0", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_4.0.gemfile
+++ b/gemfiles/activerecord_4.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.0.5", :require => "active_record"
 gem "activesupport", "~> 4.0.5", :require => "active_support/all"
 gem "actionpack", "~> 4.0.5", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_4.1.gemfile
+++ b/gemfiles/activerecord_4.1.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 4.1.1", :require => "active_record"
 gem "activesupport", "~> 4.1.1", :require => "active_support/all"
 gem "actionpack", "~> 4.1.1", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_4.2.gemfile
+++ b/gemfiles/activerecord_4.2.gemfile
@@ -6,6 +6,7 @@ gem "activerecord", "~> 4.2.0", :require => "active_record"
 gem "activesupport", "~> 4.2.0", :require => "active_support/all"
 gem "actionpack", "~> 4.2.0", :require => "action_pack"
 gem "nokogiri", "~> 1.6.8", :require => "nokogiri"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activerecord", "~> 5.0.0.rc1", :require => "active_record"
 gem "activesupport", "~> 5.0.0.rc1", :require => "active_support/all"
 gem "actionpack", "~> 5.0.0.rc1", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/gemfiles/mongoid_2.x.gemfile
+++ b/gemfiles/mongoid_2.x.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "activesupport", "~> 3.0", :require => "active_support/all"
 gem "actionpack", "~> 3.0", :require => "action_pack"
 gem "mongoid", "~> 2.0.0"
+gem "rubocop", "0.48.0"
 
 platforms :ruby, :mswin, :mingw do
   gem "bson_ext", "~> 1.1"

--- a/gemfiles/sequel_3.x.gemfile
+++ b/gemfiles/sequel_3.x.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "sequel", "~> 3.48.0"
 gem "activesupport", "~> 3.0", :require => "active_support/all"
 gem "actionpack", "~> 3.0", :require => "action_pack"
+gem "rubocop", "0.48.0"
 
 platforms :jruby do
   gem "jdbc-sqlite3"

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -144,6 +144,6 @@ module CanCan
   end
 end
 
-ActiveRecord::Base.class_eval do
-  include CanCan::ModelAdditions
+ActiveSupport.on_load(:active_record) do
+  self.send :include, CanCan::ModelAdditions
 end

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -145,5 +145,5 @@ module CanCan
 end
 
 ActiveSupport.on_load(:active_record) do
-  self.send :include, CanCan::ModelAdditions
+  send :include, CanCan::ModelAdditions
 end


### PR DESCRIPTION
# What does this PR do?

- Backports #292 into the `develop` branch for a 1.x release [Closes #405]