### PR TITLE
Raise error when ability definition includes regex

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,7 @@
 Unreleased
 
+* Raise error when an ability definition includes a regex. Previously, regexes
+  silently failed to do what you'd expect.
 * Adds support for Rails Api applications (coorasse & ajgon)
 * Controller subclasses inherit skip_load_resource from superclass (jpmckinney)
 

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -3,6 +3,9 @@ module CanCan
   # it holds the information about a "can" call made on Ability and provides
   # helpful methods to determine permission checking and conditions hash generation.
   class Rule # :nodoc:
+    E_NO_REGEX_SUPPORT = 'cancancan does not support regexes in ability ' \
+      'definitions. Contributions welcome.'.freeze
+
     attr_reader :base_behavior, :subjects, :actions, :conditions
     attr_writer :expanded_actions
 
@@ -144,6 +147,7 @@ module CanCan
 
     def condition_match?(attribute, value)
       case value
+      when Regexp     then raise(E_NO_REGEX_SUPPORT)
       when Hash       then hash_condition_match?(attribute, value)
       when String     then attribute == value
       when Range      then value.cover?(attribute)


### PR DESCRIPTION
Previously, regexes silently failed to do what you'd expect. Example:

    # consider this rule ..
    can :eat, Banana, species: /Musa/
    # and this banana ..
    Banana.new(species: 'Musa acuminata')
    # Rule#condition_match? will attempt the following comparison
    'Musa acuminata' == /Musa/

Clearly, the `==` operator is not effective here.

We could also raise this error in other places, but if we do, I think we
should still raise it here, in `condition_match?`.