### PR TITLE
Fix instance variable not initialized warnings

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -170,9 +170,8 @@ module CanCan
     end
 
     def resource_instance
-      if load_instance? && @controller.instance_variable_defined?("@#{instance_name}")
-        @controller.instance_variable_get("@#{instance_name}")
-      end
+      return unless load_instance? && @controller.instance_variable_defined?("@#{instance_name}")
+      @controller.instance_variable_get(resource_name)
     end
 
     def collection_instance=(instance)
@@ -180,9 +179,8 @@ module CanCan
     end
 
     def collection_instance
-      if @controller.instance_variable_defined?("@#{instance_name.to_s.pluralize}")
-        @controller.instance_variable_get("@#{instance_name.to_s.pluralize}")
-      end
+      return unless @controller.instance_variable_defined?("@#{instance_name.to_s.pluralize}")
+      @controller.instance_variable_get(collection_name)
     end
 
     # The object that methods (such as "find", "new" or "build") are called on.

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -170,7 +170,9 @@ module CanCan
     end
 
     def resource_instance
-      @controller.instance_variable_get("@#{instance_name}") if load_instance?
+      if load_instance? && @controller.instance_variable_defined?("@#{instance_name}")
+        @controller.instance_variable_get("@#{instance_name}")
+      end
     end
 
     def collection_instance=(instance)
@@ -178,7 +180,9 @@ module CanCan
     end
 
     def collection_instance
-      @controller.instance_variable_get("@#{instance_name.to_s.pluralize}")
+      if @controller.instance_variable_defined?("@#{instance_name.to_s.pluralize}")
+        @controller.instance_variable_get("@#{instance_name.to_s.pluralize}")
+      end
     end
 
     # The object that methods (such as "find", "new" or "build") are called on.

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -180,7 +180,7 @@ module CanCan
 
     def collection_instance
       return unless @controller.instance_variable_defined?("@#{instance_name.to_s.pluralize}")
-      @controller.instance_variable_get(collection_name)
+      @controller.instance_variable_get("@#{instance_name.to_s.pluralize}")
     end
 
     # The object that methods (such as "find", "new" or "build") are called on.

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -171,7 +171,7 @@ module CanCan
 
     def resource_instance
       return unless load_instance? && @controller.instance_variable_defined?("@#{instance_name}")
-      @controller.instance_variable_get(resource_name)
+      @controller.instance_variable_get("@#{instance_name}")
     end
 
     def collection_instance=(instance)


### PR DESCRIPTION
Fix instance variable not initialized warnings that occurred
during load_resource. This change follows the check pattern
used in fetch_parent to determine if the instance variable is
defined.