### PR TITLE
Simplify CanCan::Ability#unauthorized_message_keys

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -291,11 +291,10 @@ module CanCan
 
     def unauthorized_message_keys(action, subject)
       subject = (subject.class == Class ? subject : subject.class).name.underscore unless subject.is_a? Symbol
-      [subject, :all].map do |try_subject|
-        [aliases_for_action(action), :manage].flatten.map do |try_action|
-          :"#{try_action}.#{try_subject}"
-        end
-      end.flatten
+      aliases = aliases_for_action(action)
+      [subject, :all].product([*aliases, :manage]).map do |try_subject, try_action|
+        :"#{try_action}.#{try_subject}"
+      end
     end
 
     # Accepts an array of actions and returns an array of actions which match.


### PR DESCRIPTION
It also makes the method 1.5-2 times faster.

This is not the fastest way though. The fastest way is the following:

```ruby
    aliases =  aliases_for_action(action)
    ((aliases.map { |try_action| :"#{try_action}.#{subject}" } << :"manage.#{subject}") +
      aliases.map { |try_action| :"#{try_action}.all" }) << :'manage.all'
```

It's ~3 times faster than the original code. But the implementation is less readable, so I decided not to push it. If you think that the performance is more important than readability here - let me know, I'll update the PR accordingly.

I believe that the current state of the PR is both more readable and performant than the original.

Benchmarks:

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  subject = 'user'
  aliases = %i[read index]

  x.report('original') do
    [subject, :all].map do |try_subject|
      [aliases, :manage].flatten.map do |try_action|
        :"#{try_action}.#{try_subject}"
      end
    end.flatten
  end

  x.report('flat_map') do
    [subject, :all].flat_map do |try_subject|
      [*aliases, :manage].map do |try_action|
        :"#{try_action}.#{try_subject}"
      end
    end
  end

  x.report('product') do
    [subject, :all].product([*aliases, :manage]).map do |try_subject, try_action|
      :"#{try_action}.#{try_subject}"
    end
  end

  x.report('two maps and +') do
    t = [*aliases, :manage]
    t.map { |try_action| :"#{try_action}.#{subject}" } +
      t.map { |try_action| :"#{try_action}.all" }
  end

  x.report('two maps and concat') do
    t = [*aliases, :manage]
    t.map { |try_action| :"#{try_action}.#{subject}" }.concat(
      t.map { |try_action| :"#{try_action}.all" }
    )
  end

  x.report('maps and <<') do
    ((aliases.map { |try_action| :"#{try_action}.#{subject}" } << :"manage.#{subject}") +
      aliases.map { |try_action| :"#{try_action}.all" }) << :'manage.all'
  end

  x.report('maps and splats') do
    [
      *aliases.map { |try_action| :"#{try_action}.#{subject}" },
      :"manage.#{subject}",
      *aliases.map { |try_action| :"#{try_action}.all" },
      :'manage.all'
    ]
  end

  x.compare!
end
__END__
[76] pry(main)> load './bench2.rb'
Warming up --------------------------------------
            original    12.453k i/100ms
            flat_map    19.739k i/100ms
             product    18.458k i/100ms
      two maps and +    25.374k i/100ms
 two maps and concat    24.903k i/100ms
         maps and <<    31.637k i/100ms
     maps and splats    25.906k i/100ms
Calculating -------------------------------------
            original    127.846k (± 6.8%) i/s -    647.556k in   5.085779s
            flat_map    202.823k (± 4.1%) i/s -      1.026M in   5.069522s
             product    197.654k (± 5.7%) i/s -    996.732k in   5.058522s
      two maps and +    275.584k (± 5.3%) i/s -      1.396M in   5.079233s
 two maps and concat    280.054k (± 5.4%) i/s -      1.419M in   5.082031s
         maps and <<    356.361k (± 5.8%) i/s -      1.803M in   5.075111s
     maps and splats    282.329k (± 6.6%) i/s -      1.425M in   5.065338s

Comparison:
         maps and <<:   356361.3 i/s
     maps and splats:   282329.4 i/s - 1.26x  slower
 two maps and concat:   280054.0 i/s - 1.27x  slower
      two maps and +:   275584.4 i/s - 1.29x  slower
            flat_map:   202822.9 i/s - 1.76x  slower
             product:   197654.2 i/s - 1.80x  slower
            original:   127845.7 i/s - 2.79x  slower
```