### PR TITLE
Add ability to build new instances with `new_params` on `new` action

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,7 +1,8 @@
 Unreleased
 
-* Adds support for Rails Api applications (coorasse & ajgon)
+* Adds support for Rails API applications (coorasse & ajgon)
 * Controller subclasses inherit skip_load_resource from superclass (jpmckinney)
+* Adds support for `new_params` for instantiating instances with custom params (joelvh)
 
 2.0.0 (May 18th, 2017)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ### Reporting an Issue
 
-1. If you have any questions about CanCanCan, search the [Wiki](https://github.com/cancancommunity/cancancan/wiki) or 
-use [Stack Overflow](http://stackoverflow.com/questions/tagged/cancancan). 
+1. If you have any questions about CanCanCan, search the [Wiki](https://github.com/cancancommunity/cancancan/wiki) or
+use [Stack Overflow](http://stackoverflow.com/questions/tagged/cancancan).
 Do not post questions here.
 
 1. If you find a security bug, **DO NOT** submit an issue here. Please send an e-mail to the [current maintainer](https://github.com/coorasse) instead.
@@ -17,11 +17,11 @@ That's it! The more information you give, the more easy it becomes for us to tra
 ### Adding new Features or Bugfixes
 
 CanCanCan uses a [git-flow](http://nvie.com/posts/a-successful-git-branching-model/) development model.
-The latest "released" version of CanCanCan, the latest gem version, can always be found on `master`, 
+The latest "released" version of CanCanCan, the latest gem version, can always be found on `master`,
 while the next version or nightly is on `develop`.
 
 Please make sure you have test coverage for anything you add or fix!
 
-Please add a CHANGELOG entry with any relevant tags for issues, pull-requests, and authors.
+Please add a [CHANGELOG](https://github.com/cancancommunity/cancancan/CHANGELOG.rdoc) entry with any relevant tags for issues, pull-requests, and authors.
 
 Thanks for you contribution!

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -243,9 +243,21 @@ module CanCan
         when Proc then
           params_method.call(@controller)
         end
+      elsif build_params_method
+        @controller.send(build_params_method)
       else
         resource_params_by_namespaced_name
       end
+    end
+
+    def build_params_method
+      return unless new_actions.include?(@params[:action].to_sym)
+
+      method_name = "#{@params[:action]}_params".to_sym
+
+      return unless @controller.respond_to?(method_name, true)
+
+      method_name
     end
 
     def parameters_require_sanitizing?

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -77,7 +77,7 @@ module CanCan
       private
 
       def mergeable_conditions?
-        @rules.find(&:unmergeable?).blank?
+        @rules.none?(&:unmergeable?)
       end
 
       def override_scope

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -188,7 +188,7 @@ describe CanCan::ControllerResource do
 
     context 'with a build parameters method' do
       it 'prefers to use the new_params method for initializing instances' do
-        params.merge!(action: 'new')
+        params[:action] = 'new'
         allow(controller).to receive(:resource_params).and_return(resource: 'params')
         allow(controller).to receive(:model_params).and_return(model: 'params')
         allow(controller).to receive(:custom_params).and_return(custom: 'params')
@@ -201,7 +201,7 @@ describe CanCan::ControllerResource do
       end
 
       it 'prefers to use the new_params method for initializing instances' do
-        params.merge!(action: 'create')
+        params[:action] = 'create'
         allow(controller).to receive(:resource_params).and_return(resource: 'params')
         allow(controller).to receive(:model_params).and_return(model: 'params')
         allow(controller).to receive(:custom_params).and_return(custom: 'params')

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -185,6 +185,34 @@ describe CanCan::ControllerResource do
         expect(resource.send('resource_params')).to eq(resource: 'params')
       end
     end
+
+    context 'with a build parameters method' do
+      it 'prefers to use the new_params method for initializing instances' do
+        params.merge!(action: 'new')
+        allow(controller).to receive(:resource_params).and_return(resource: 'params')
+        allow(controller).to receive(:model_params).and_return(model: 'params')
+        allow(controller).to receive(:custom_params).and_return(custom: 'params')
+        allow(controller).to receive(:new_params).and_return(name: 'new')
+        allow(controller).to receive(:create_params).and_return(name: 'create')
+        resource = CanCan::ControllerResource.new(controller)
+        resource.load_resource
+        expect(resource.send(:build_params_method)).to eq :new_params
+        expect(resource.send(:resource_instance).name).to eq 'new'
+      end
+
+      it 'prefers to use the new_params method for initializing instances' do
+        params.merge!(action: 'create')
+        allow(controller).to receive(:resource_params).and_return(resource: 'params')
+        allow(controller).to receive(:model_params).and_return(model: 'params')
+        allow(controller).to receive(:custom_params).and_return(custom: 'params')
+        allow(controller).to receive(:new_params).and_return(name: 'new')
+        allow(controller).to receive(:create_params).and_return(name: 'create')
+        resource = CanCan::ControllerResource.new(controller)
+        resource.load_resource
+        expect(resource.send(:build_params_method)).to eq :create_params
+        expect(resource.send(:resource_instance).name).to eq 'create'
+      end
+    end
   end
 
   context 'on collection actions' do


### PR DESCRIPTION
This enhancement provides the ability to specify the default attributes that are used when instantiating a new instance on the `new` action. Currently, `ControllerResource#resource_params` does not consider the `new` action as needing "sanitization", therefore it doesn't detect the `new_params` method on the controller if you've specified it.

This is a simple update to add the ability to specify defaults with `new_params` method on your controller. 