### PR TITLE
Add support to translate model_name

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -181,9 +181,18 @@ module CanCan
     def unauthorized_message(action, subject)
       keys = unauthorized_message_keys(action, subject)
       variables = { action: action.to_s }
-      variables[:subject] = (subject.class == Class ? subject : subject.class).to_s.underscore.humanize.downcase
+      variables[:subject] = translate_subject(subject)
       message = I18n.translate(keys.shift, variables.merge(scope: :unauthorized, default: keys + ['']))
       message.blank? ? nil : message
+    end
+
+    def translate_subject(subject)
+      klass = (subject.class == Class ? subject : subject.class)
+      if klass.respond_to?(:model_name)
+        klass.model_name.human
+      else
+        klass.to_s.underscore.humanize.downcase
+      end
     end
 
     def attributes_for(action, subject)

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -202,6 +202,28 @@ module CanCan
       relevant_rules(action, subject).any?(&:only_raw_sql?)
     end
 
+    # Copies all rules of the given +CanCan::Ability+ and adds them to +self+.
+    #   class ReadAbility
+    #     include CanCan::Ability
+    #
+    #     def initialize
+    #       can :read, User
+    #     end
+    #   end
+    #
+    #   class WritingAbility
+    #     include CanCan::Ability
+    #
+    #     def initialize
+    #       can :edit, User
+    #     end
+    #   end
+    #
+    #   read_ability = ReadAbility.new
+    #   read_ability.can? :edit, User.new #=> false
+    #   read_ability.merge(WritingAbility.new)
+    #   read_ability.can? :edit, User.new #=> true
+    #
     def merge(ability)
       ability.rules.each do |rule|
         add_rule(rule.dup)

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -506,12 +506,18 @@ describe CanCan::Ability do
         include ActiveModel::Model
       end
 
-      I18n.default_locale = :ja
+      I18n.backend.store_translations :en,
+                                      activemodel: { models: { account: 'english name' } },
+                                      unauthorized: { update: { all: '%{subject}' } }
       I18n.backend.store_translations :ja,
-                                      activemodel: { models: { account: 'アカウント' } },
-                                      unauthorized: { update: { all: '%{subject}の更新権限がありません' } }
-      expect(@ability.unauthorized_message(:update, Account)).to eq('アカウントの更新権限がありません')
-      # rubocop:enable Style/FormatString
+                                      activemodel: { models: { account: 'japanese name' } },
+                                      unauthorized: { update: { all: '%{subject}' } }
+
+      I18n.default_locale = :en
+      expect(@ability.unauthorized_message(:update, Account)).to eq('english name')
+
+      I18n.default_locale = :ja
+      expect(@ability.unauthorized_message(:update, Account)).to eq('japanese name')
     end
 
     it 'uses symbol as subject directly' do

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -491,6 +491,7 @@ describe CanCan::Ability do
   describe 'unauthorized message' do
     after(:each) do
       I18n.backend = nil
+      I18n.default_locale = :en
     end
 
     it 'uses action/subject in i18n' do
@@ -498,6 +499,19 @@ describe CanCan::Ability do
       expect(@ability.unauthorized_message(:update, Array)).to eq('foo')
       expect(@ability.unauthorized_message(:update, [1, 2, 3])).to eq('foo')
       expect(@ability.unauthorized_message(:update, :missing)).to be_nil
+    end
+
+    it "uses model's name in i18n" do
+      class Account
+        include ActiveModel::Model
+      end
+
+      I18n.default_locale = :ja
+      I18n.backend.store_translations :ja,
+                                      activemodel: { models: { account: 'アカウント' } },
+                                      unauthorized: { update: { all: '%{subject}の更新権限がありません' } }
+      expect(@ability.unauthorized_message(:update, Account)).to eq('アカウントの更新権限がありません')
+      # rubocop:enable Style/FormatString
     end
 
     it 'uses symbol as subject directly' do

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -491,7 +491,6 @@ describe CanCan::Ability do
   describe 'unauthorized message' do
     after(:each) do
       I18n.backend = nil
-      I18n.default_locale = :en
     end
 
     it 'uses action/subject in i18n' do
@@ -513,11 +512,13 @@ describe CanCan::Ability do
                                       activemodel: { models: { account: 'japanese name' } },
                                       unauthorized: { update: { all: '%{subject}' } }
 
-      I18n.default_locale = :en
-      expect(@ability.unauthorized_message(:update, Account)).to eq('english name')
+      I18n.with_locale(:en) do
+        expect(@ability.unauthorized_message(:update, Account)).to eq('english name')
+      end
 
-      I18n.default_locale = :ja
-      expect(@ability.unauthorized_message(:update, Account)).to eq('japanese name')
+      I18n.with_locale(:ja) do
+        expect(@ability.unauthorized_message(:update, Account)).to eq('japanese name')
+      end
     end
 
     it 'uses symbol as subject directly' do


### PR DESCRIPTION
This PR allows to translate a model's name in unauthorized message using ActiveSupport I18n.