### PR TITLE
lock activerecord-jdbcsqlite3-adapter for Rails 4

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,7 +5,7 @@ appraise 'activerecord_4.2' do
   gem 'nokogiri', '~> 1.6.8', require: 'nokogiri' # TODO: fix for ruby 2.0.0
 
   gemfile.platforms :jruby do
-    gem 'activerecord-jdbcsqlite3-adapter'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.24'
     gem 'jdbc-sqlite3'
   end
 

--- a/gemfiles/activerecord_4.2.gemfile
+++ b/gemfiles/activerecord_4.2.gemfile
@@ -8,7 +8,7 @@ gem "actionpack", "~> 4.2.0", require: "action_pack"
 gem "nokogiri", "~> 1.6.8", require: "nokogiri"
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter"
+  gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.24"
   gem "jdbc-sqlite3"
 end
 


### PR DESCRIPTION
activerecord-jdbcsqlite3-adapter has a new major version to support Rails 5. This broke the previous builds. Version is now locked for Rails 5 and new configurations will be added for Rails 5