### PR TITLE
Optimised queries by using left_joins in Rails 5.2 or above

### DIFF
--- a/lib/cancan/model_adapters/active_record_5_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_5_adapter.rb
@@ -28,7 +28,15 @@ module CanCan
       # in addition to `includes()` to force the outer join.
       def build_relation(*where_conditions)
         relation = @model_class.where(*where_conditions)
-        relation = relation.includes(joins).references(joins) if joins.present?
+
+        if joins.present?
+          if Rails::VERSION::MAJOR >= 5 || Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 2
+            relation = relation.left_joins(joins)
+          else
+            relation = relation.includes(joins).references(joins)
+          end
+        end
+
         relation
       end
 


### PR DESCRIPTION
Simplified version of #238 

This greatly simplifies the generated SQL queries and optimises performance, because records aren't unnecessarily preloaded when using `left_joins(...)` instead `.includes(...).references(...)`