### PR TITLE
Remove support for ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.2.8
   - 2.3.5
   - 2.4.2
   - 2.5.0
+  - 2.5.1
   - jruby-9.0.5.0
   - jruby-9.1.9.0
 gemfile:
@@ -18,14 +18,6 @@ services:
 matrix:
   fast_finish: true
   exclude:
-    - rvm: 2.2.0
-      gemfile: gemfiles/activerecord_5.0.2.gemfile
-    - rvm: 2.2.0
-      gemfile: gemfiles/activerecord_5.1.0.gemfile
-    - rvm: 2.2.7
-      gemfile: gemfiles/activerecord_5.0.2.gemfile
-    - rvm: 2.2.7
-      gemfile: gemfiles/activerecord_5.1.0.gemfile
     - rvm: jruby-9.0.5.0
       gemfile: gemfiles/activerecord_5.0.2.gemfile
     - rvm: jruby-9.1.9.0
@@ -42,7 +34,6 @@ notifications:
   email:
     recipients:
       - alessandro.rodi@renuo.ch
-      - josua.schmid@renuo.ch
     on_success: change
     on_failure: change
 before_install:

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,5 +1,7 @@
 Unreleased
 
+* Remove ruby 2.2 from Travis and add ruby 2.5.1 (coorasse)
+
 2.2.0 (Apr 13th, 2018)
 
 * Include conditions passed to authorize! in AccessDenied exception (kraflab)


### PR DESCRIPTION
Following the ruby announcement, also our support for ruby 2.2 will not be guaranteed anymore.
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/