### PR TITLE
Predict associations names

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+version: "2"
+checks:
+  argument-count:
+    config:
+      threshold: 5

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -2,6 +2,8 @@ Unreleased
 
 * Compress irrelevant rules before generating a query to optimize performances (coorasse)
 * Remove ruby 2.2 from Travis and add ruby 2.5.1 (coorasse)
+* Predict associations names to support multiple references to the same table (coorasse)
+* Raise a specific exception when using a wrong association name in rules definition (@coorasse)
 
 2.2.0 (Apr 13th, 2018)
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ Version 2.0 drops also support for Rails < 4.2 and ruby < 2.2 so, again, use the
 
 ## Wiki Docs
 
-* [Upgrading to 1.6](https://github.com/CanCanCommunity/cancancan/wiki/Upgrading-to-1.6)
 * [Defining Abilities](https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities)
 * [Checking Abilities](https://github.com/CanCanCommunity/cancancan/wiki/Checking-Abilities)
 * [Authorizing Controller Actions](https://github.com/CanCanCommunity/cancancan/wiki/Authorizing-Controller-Actions)

--- a/lib/cancan.rb
+++ b/lib/cancan.rb
@@ -11,6 +11,7 @@ require 'cancan/model_adapters/default_adapter'
 require 'cancan/rules_compressor'
 
 if defined? ActiveRecord
+  require 'cancan/model_adapters/conditions_extractor'
   require 'cancan/model_adapters/active_record_adapter'
   require 'cancan/model_adapters/active_record_4_adapter'
   require 'cancan/model_adapters/active_record_5_adapter'

--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -11,6 +11,9 @@ module CanCan
   # Raised when using check_authorization without calling authorized!
   class AuthorizationNotPerformed < Error; end
 
+  # Raised when using a wrong association name
+  class WrongAssociationName < Error; end
+
   # This error is raised when a user isn't allowed to access a given controller action.
   # This usually happens within a call to ControllerAdditions#authorize! but can be
   # raised manually.

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -1,4 +1,5 @@
 require_relative 'can_can/model_adapters/active_record_adapter/joins.rb'
+require_relative 'conditions_extractor.rb'
 require 'cancan/rules_compressor'
 module CanCan
   module ModelAdapters
@@ -22,47 +23,18 @@ module CanCan
       #
       def conditions
         compressed_rules = RulesCompressor.new(@rules.reverse).rules_collapsed.reverse
+        conditions_extractor = ConditionsExtractor.new(@model_class)
         if compressed_rules.size == 1 && compressed_rules.first.base_behavior
           # Return the conditions directly if there's just one definition
-          tableized_conditions(compressed_rules.first.conditions).dup
+          conditions_extractor.tableize_conditions(compressed_rules.first.conditions).dup
         else
-          extract_multiple_conditions(compressed_rules)
+          extract_multiple_conditions(conditions_extractor, compressed_rules)
         end
       end
 
-      def extract_multiple_conditions(rules)
+      def extract_multiple_conditions(conditions_extractor, rules)
         rules.reverse.inject(false_sql) do |sql, rule|
-          merge_conditions(sql, tableized_conditions(rule.conditions).dup, rule.base_behavior)
-        end
-      end
-
-      def tableized_conditions(conditions, model_class = @model_class)
-        return conditions unless conditions.is_a? Hash
-        conditions.each_with_object({}) do |(name, value), result_hash|
-          calculate_result_hash(model_class, name, result_hash, value)
-        end
-      end
-
-      def calculate_result_hash(model_class, name, result_hash, value)
-        if value.is_a? Hash
-          association_class = model_class.reflect_on_association(name).klass.name.constantize
-          nested_resulted = calculate_nested(model_class, name, result_hash, value.dup)
-          result_hash.merge!(tableized_conditions(nested_resulted, association_class))
-        else
-          result_hash[name] = value
-        end
-        result_hash
-      end
-
-      def calculate_nested(model_class, name, result_hash, value)
-        value.each_with_object({}) do |(k, v), nested|
-          if v.is_a? Hash
-            value.delete(k)
-            nested[k] = v
-          else
-            result_hash[model_class.reflect_on_association(name).table_name.to_sym] = value
-          end
-          nested
+          merge_conditions(sql, conditions_extractor.tableize_conditions(rule.conditions).dup, rule.base_behavior)
         end
       end
 

--- a/lib/cancan/model_adapters/can_can/model_adapters/active_record_adapter/joins.rb
+++ b/lib/cancan/model_adapters/can_can/model_adapters/active_record_adapter/joins.rb
@@ -6,7 +6,7 @@ module CanCan
         # See ModelAdditions#accessible_by
         def joins
           joins_hash = {}
-          @rules.each do |rule|
+          @rules.reverse.each do |rule|
             merge_joins(joins_hash, rule.associations_hash)
           end
           clean_joins(joins_hash) unless joins_hash.empty?

--- a/lib/cancan/model_adapters/conditions_extractor.rb
+++ b/lib/cancan/model_adapters/conditions_extractor.rb
@@ -1,0 +1,75 @@
+# this class is responsible of converting the hash of conditions
+# in "where conditions" to generate the sql query
+# it consists of a names_cache that helps calculating the next name given to the association
+# it tries to reflect the bahavior of ActiveRecord when generating aliases for tables.
+module CanCan
+  module ModelAdapters
+    class ConditionsExtractor
+      def initialize(model_class)
+        @names_cache = { model_class.table_name => [] }.with_indifferent_access
+        @root_model_class = model_class
+      end
+
+      def tableize_conditions(conditions, model_class = @root_model_class, path_to_key = 0)
+        return conditions unless conditions.is_a? Hash
+        conditions.each_with_object({}) do |(key, value), result_hash|
+          if value.is_a? Hash
+            result_hash.merge!(calculate_result_hash(key, model_class, path_to_key, result_hash, value))
+          else
+            result_hash[key] = value
+          end
+          result_hash
+        end
+      end
+
+      private
+
+      def calculate_result_hash(key, model_class, path_to_key, result_hash, value)
+        reflection = model_class.reflect_on_association(key)
+        unless reflection
+          raise WrongAssociationName, "association #{key} not defined in model #{model_class.name}"
+        end
+        nested_resulted = calculate_nested(model_class, result_hash, key, value.dup, path_to_key)
+        association_class = reflection.klass.name.constantize
+        tableize_conditions(nested_resulted, association_class, "#{path_to_key}_#{key}")
+      end
+
+      def calculate_nested(model_class, result_hash, relation_name, value, path_to_key)
+        value.each_with_object({}) do |(k, v), nested|
+          if v.is_a? Hash
+            value.delete(k)
+            nested[k] = v
+          else
+            table_alias = generate_table_alias(model_class, relation_name, path_to_key)
+            result_hash[table_alias] = value
+          end
+          nested
+        end
+      end
+
+      def generate_table_alias(model_class, relation_name, path_to_key)
+        table_alias = model_class.reflect_on_association(relation_name).table_name.to_sym
+
+        if alredy_used?(table_alias, relation_name, path_to_key)
+          table_alias = "#{relation_name.to_s.pluralize}_#{model_class.table_name}".to_sym
+
+          index = 1
+          while alredy_used?(table_alias, relation_name, path_to_key)
+            table_alias = "#{table_alias}_#{index += 1}".to_sym
+          end
+        end
+        add_to_cache(table_alias, relation_name, path_to_key)
+      end
+
+      def alredy_used?(table_alias, relation_name, path_to_key)
+        @names_cache[table_alias].try(:exclude?, "#{path_to_key}_#{relation_name}")
+      end
+
+      def add_to_cache(table_alias, relation_name, path_to_key)
+        @names_cache[table_alias] ||= []
+        @names_cache[table_alias] << "#{path_to_key}_#{relation_name}"
+        table_alias
+      end
+    end
+  end
+end

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -41,6 +41,7 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
         end
 
         create_table(:users) do |t|
+          t.string :name
           t.timestamps null: false
         end
       end
@@ -72,6 +73,8 @@ if defined? CanCan::ModelAdapters::ActiveRecordAdapter
 
       class User < ActiveRecord::Base
         has_many :articles
+        has_many :mentions
+        has_many :mentioned_articles, through: :mentions, source: :article
       end
 
       (@ability = double).extend(CanCan::Ability)
@@ -414,6 +417,52 @@ WHERE "articles"."published" = 'f' AND "articles"."secret" = 't'))
         valid_course = Course.create!(start_at: Time.now)
 
         expect(Course.accessible_by(@ability)).to eq([valid_course])
+      end
+    end
+
+    context 'when a table references another one twice' do
+      before do
+        ActiveRecord::Schema.define do
+          create_table(:transactions) do |t|
+            t.integer :sender_id
+            t.integer :receiver_id
+          end
+        end
+
+        class Transaction < ActiveRecord::Base
+          belongs_to :sender, class_name: 'User', foreign_key: :sender_id
+          belongs_to :receiver, class_name: 'User', foreign_key: :receiver_id
+        end
+      end
+
+      it 'can filter correctly on both associations' do
+        sender = User.create!
+        receiver = User.create!
+        t1 = Transaction.create!(sender: sender, receiver: receiver)
+        t2 = Transaction.create!(sender: receiver, receiver: sender)
+
+        ability = Ability.new(sender)
+        ability.can :read, Transaction, sender: { id: sender.id }
+        ability.can :read, Transaction, receiver: { id: sender.id }
+        expect(Transaction.accessible_by(ability)).to eq([t1, t2])
+      end
+    end
+
+    context 'when a table is references multiple times' do
+      it 'can filter correctly on the different associations' do
+        u1 = User.create!(name: 'pippo')
+        u2 = User.create!(name: 'paperino')
+
+        a1 = Article.create!(user: u1)
+        a2 = Article.create!(user: u2)
+
+        ability = Ability.new(u1)
+        ability.can :read, Article, user: { id: u1.id }
+        ability.can :read, Article, mentioned_users: { name: u1.name }
+        ability.can :read, Article, mentioned_users: { mentioned_articles: { id: a2.id } }
+        ability.can :read, Article, mentioned_users: { articles: { user: { name: 'deep' } } }
+        ability.can :read, Article, mentioned_users: { articles: { mentioned_users: { name: 'd2' } } }
+        expect(Article.accessible_by(ability)).to eq([a1])
       end
     end
   end

--- a/spec/cancan/model_adapters/conditions_extractor_spec.rb
+++ b/spec/cancan/model_adapters/conditions_extractor_spec.rb
@@ -1,0 +1,149 @@
+require 'spec_helper'
+
+if defined? CanCan::ModelAdapters::ConditionsExtractor
+  RSpec.describe CanCan::ModelAdapters::ConditionsExtractor do
+    before do
+      ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+      ActiveRecord::Migration.verbose = false
+      ActiveRecord::Schema.define do
+        create_table(:categories) do |t|
+          t.string :name
+          t.boolean :visible
+          t.timestamps null: false
+        end
+
+        create_table(:projects) do |t|
+          t.string :name
+          t.timestamps null: false
+        end
+
+        create_table(:articles) do |t|
+          t.string :name
+          t.timestamps null: false
+          t.boolean :published
+          t.boolean :secret
+          t.integer :priority
+          t.integer :category_id
+          t.integer :user_id
+        end
+
+        create_table(:comments) do |t|
+          t.boolean :spam
+          t.integer :article_id
+          t.timestamps null: false
+        end
+
+        create_table(:legacy_mentions) do |t|
+          t.integer :user_id
+          t.integer :article_id
+          t.timestamps null: false
+        end
+
+        create_table(:users) do |t|
+          t.timestamps null: false
+        end
+
+        create_table(:transactions) do |t|
+          t.integer :sender_id
+          t.integer :receiver_id
+          t.integer :supervisor_id
+        end
+      end
+
+      class Project < ActiveRecord::Base
+      end
+
+      class Category < ActiveRecord::Base
+        has_many :articles
+      end
+
+      class Article < ActiveRecord::Base
+        belongs_to :category
+        has_many :comments
+        has_many :mentions
+        has_many :mentioned_users, through: :mentions, source: :user
+        belongs_to :user
+      end
+
+      class Mention < ActiveRecord::Base
+        self.table_name = 'legacy_mentions'
+        belongs_to :user
+        belongs_to :article
+      end
+
+      class Comment < ActiveRecord::Base
+        belongs_to :article
+      end
+
+      class User < ActiveRecord::Base
+        has_many :articles
+        has_many :mentions
+        has_many :mentioned_articles, through: :mentions, source: :article
+      end
+
+      class Transaction < ActiveRecord::Base
+        belongs_to :sender, class_name: 'User', foreign_key: :sender_id
+        belongs_to :receiver, class_name: 'User', foreign_key: :receiver_id
+        belongs_to :supervisor, class_name: 'User', foreign_key: :supervisor_id
+      end
+    end
+
+    describe 'converts hash of conditions into database sql where format' do
+      it 'converts a simple association' do
+        conditions = described_class.new(User).tableize_conditions(articles: { id: 1 })
+        expect(conditions).to eq(articles: { id: 1 })
+      end
+
+      it 'converts a nested association' do
+        conditions = described_class.new(User).tableize_conditions(articles: { category: { id: 1 } })
+        expect(conditions).to eq(categories: { id: 1 })
+      end
+
+      it 'converts two associations' do
+        conditions = described_class.new(User).tableize_conditions(articles: { id: 2, category: { id: 1 } })
+        expect(conditions).to eq(articles: { id: 2 }, categories: { id: 1 })
+      end
+
+      it 'converts has_many through' do
+        conditions = described_class.new(Article).tableize_conditions(mentioned_users: { id: 1 })
+        expect(conditions).to eq(users: { id: 1 })
+      end
+
+      it 'converts associations named differently from the table' do
+        conditions = described_class.new(Transaction).tableize_conditions(sender: { id: 1 })
+        expect(conditions).to eq(users: { id: 1 })
+      end
+
+      it 'converts associations properly when the same table is referenced twice' do
+        conditions = described_class.new(Transaction).tableize_conditions(sender: { id: 1 }, receiver: { id: 2 })
+        expect(conditions).to eq(users: { id: 1 }, receivers_transactions: { id: 2 })
+      end
+
+      it 'converts very complex nested sets' do
+        original_conditions = { user: { id: 1 },
+                                mentioned_users: { name: 'a name',
+                                                   mentioned_articles: { id: 2 },
+                                                   articles: { user: { name: 'deep' },
+                                                               mentioned_users: { name: 'd2' } } } }
+
+        conditions = described_class.new(Article).tableize_conditions(original_conditions)
+        expect(conditions).to eq(users: { id: 1 },
+                                 mentioned_articles_users: { id: 2 },
+                                 mentioned_users_articles: { name: 'a name' },
+                                 users_articles: { name: 'deep' },
+                                 mentioned_users_articles_2: { name: 'd2' })
+      end
+
+      it 'converts complex nested sets with duplicates' do
+        original_conditions = { sender: { id: 'sender', articles: { id: 'article1' } },
+                                receiver: { id: 'receiver', articles: { id: 'article2' } } }
+
+        conditions = described_class.new(Transaction).tableize_conditions(original_conditions)
+        expect(conditions).to eq(users: { id: 'sender' },
+                                 articles: { id: 'article1' },
+                                 receivers_transactions: { id: 'receiver' },
+                                 articles_users: { id: 'article2' })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rainy weekends... ⛈ 
This PR aims to solve the issues #523, #337 and close #518, #363.
Let's recap it to "the problem of the same table referenced twice".
This problem is not of CanCanCan, directly but, rather of ActiveRecord (see issues: https://github.com/rails/rails/issues/606).

**Sum up**
I cannot ask ActiveRecord to tell me the alias that will give to an association, once the SQL is generated.

**What we have tried**
Following the issues mentioned above, we tried to fix the problem first by switching to Arel and then using UNIONs.

The rewrite of CanCanCan into Arel has been excluded due to the fact that it would mean a huge rewrite and possible conflicts with ActiveRecord.

The usage of UNIONs has been experimented and had succeeded, but it caused a significative decrease of the performance.

**What does this PR do**
This PR extracts the calculation of the table aliases in a separate class which *tries* to mimic ActiveRecord behaviour when assigning an alias to a table.
This method is not bullet proof but is rather cheap in terms of execution time and solves the simplest cases. I would define it a good compromise to let the simplest situations be working.

It also adds a nice exception message when a wrong association name is used in the abilities definition.