### PR TITLE
Merge alias actions when merging abilities

### DIFF
--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -564,6 +564,35 @@ describe CanCan::Ability do
       expect(@ability.send(:rules).size).to eq(2)
     end
 
+    it 'adds the aliased actions from the given ability' do
+      @ability.alias_action :show, to: :see
+      (another_ability = double).extend(CanCan::Ability)
+      another_ability.alias_action :create, :update, to: :manage
+
+      @ability.merge(another_ability)
+      expect(@ability.aliased_actions).to eq(
+        read: %i[index show],
+        create: %i[new],
+        update: %i[edit],
+        manage: %i[create update],
+        see: %i[show]
+      )
+    end
+
+    it 'overwrittes the aliased actions with the value from the given ability' do
+      @ability.alias_action :show, :index, to: :see
+      (another_ability = double).extend(CanCan::Ability)
+      another_ability.alias_action :show, to: :see
+
+      @ability.merge(another_ability)
+      expect(@ability.aliased_actions).to eq(
+        read: %i[index show],
+        create: %i[new],
+        update: %i[edit],
+        see: %i[show]
+      )
+    end
+
     it 'can add an empty ability' do
       (another_ability = double).extend(CanCan::Ability)
 


### PR DESCRIPTION
Closes https://github.com/CanCanCommunity/cancancan/issues/468
Closes https://github.com/CanCanCommunity/cancancan/issues/280

This changes the behaviour of `Ability#merge` to also include defined
`alias_actions`.

If a collision between the defined aliases occurs the actions on `self`
will be overwritten with those on the passed object. For an example see [this added spec](https://github.com/Jcambass/cancancan/blob/b41eb95407409a5e76f1e7c99f524a8c29fec925/spec/cancan/ability_spec.rb#L582).

The inline documentation has been updated in order to reflect those
changes.