### PR TITLE
Update spec/README.rdoc to followup current situation

### DIFF
--- a/spec/README.rdoc
+++ b/spec/README.rdoc
@@ -16,11 +16,11 @@ You can then run all test sets:
 
 Or individual ones:
 
-  appraisal activerecord_3.2 rake
+  appraisal activerecord_5.2.0 rake
 
 A list of the tests is in the +Appraisal+ file.
 
-The specs support Ruby 1.8.7+
+The specs support Ruby 2.3+
 
 == Model Adapters
 


### PR DESCRIPTION
* gemfile for activerecord_3.2 was removed.
* Current supported Ruby version is 2.3+.
  https://github.com/CanCanCommunity/cancancan/pull/529