### PR TITLE
Update invalid changelog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ See the [CONTRIBUTING](https://github.com/CanCanCommunity/cancancan/blob/develop
 Thanks to [Renuo AG](https://www.renuo.ch) for currently maintaining and supporting the project.
 
 Also many thanks to the [CanCanCan contributors](https://github.com/CanCanCommunity/cancancan/contributors). 
-See the [CHANGELOG](https://github.com/CanCanCommunity/cancancan/blob/master/CHANGELOG.rdoc) for the full list.
+See the [CHANGELOG](https://github.com/CanCanCommunity/cancancan/blob/master/CHANGELOG.md) for the full list.
 
 CanCanCan was inspired by [declarative_authorization](https://github.com/stffn/declarative_authorization/) and 
 [aegis](https://github.com/makandra/aegis). 


### PR DESCRIPTION
In README, the changelog was referenced with the old rdoc extension.