### PR TITLE
Fix typos referring to authorized! method

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -225,7 +225,7 @@ module CanCan
         cancan_skipper[:authorize][name] = options
       end
 
-      # Add this to a controller to ensure it performs authorization through +authorized+! or +authorize_resource+ call.
+      # Add this to a controller to ensure it performs authorization through +authorize+! or +authorize_resource+ call.
       # If neither of these authorization methods are called,
       # a CanCan::AuthorizationNotPerformed exception will be raised.
       # This is normally added to the ApplicationController to ensure all controller actions do authorization.

--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -8,7 +8,7 @@ module CanCan
   # Raised when removed code is called, an alternative solution is provided in message.
   class ImplementationRemoved < Error; end
 
-  # Raised when using check_authorization without calling authorized!
+  # Raised when using check_authorization without calling authorize!
   class AuthorizationNotPerformed < Error; end
 
   # Raised when using a wrong association name
@@ -33,7 +33,7 @@ module CanCan
   #   exception.default_message = "Default error message"
   #   exception.message # => "Default error message"
   #
-  # See ControllerAdditions#authorized! for more information on rescuing from this exception
+  # See ControllerAdditions#authorize! for more information on rescuing from this exception
   # and customizing the message using I18n.
   class AccessDenied < Error
     attr_reader :action, :subject, :conditions


### PR DESCRIPTION
A few comments refer to `ControllerAdditions#authorized!`, but the method is actually `ControllerAdditions#authorize!`. This PR updates the comments with the correct name.