### PR TITLE
Avoid multiple queries on session dump

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -29,6 +29,13 @@ module CanCan
       @block = block
     end
 
+    def inspect
+      repr = "#<#{self.class.name}"
+      repr << "#{@base_behavior ? 'can' : 'cannot'} #{@actions.inspect}, #{@subjects.inspect}, #{@attributes.inspect}"
+      repr << @conditions.inspect.to_s if [Hash, String].include?(@conditions.class)
+      repr << '>'
+    end
+
     def can_rule?
       base_behavior
     end

--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -58,4 +58,35 @@ RSpec.describe CanCan::Rule do
     expect(rule2.attributes).to eq []
     expect(rule2.conditions).to eq %i[foo bar]
   end
+
+  describe '#inspect' do
+    def count_queries(&block)
+      count = 0
+      counter_f = lambda { |_name, _started, _finished, _unique_id, payload|
+        count += 1 unless payload[:name].in? %w[CACHE SCHEMA]
+      }
+      ActiveSupport::Notifications.subscribed(counter_f, 'sql.active_record', &block)
+      count
+    end
+
+    before do
+      ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+      ActiveRecord::Migration.verbose = false
+      ActiveRecord::Schema.define do
+        create_table(:watermelons) do |t|
+          t.boolean :visible
+        end
+      end
+
+      class Watermelon < ActiveRecord::Base
+        scope :visible, -> { where(visible: true) }
+      end
+    end
+
+    it 'does not evaluate the conditions when they are scopes' do
+      rule = CanCan::Rule.new(true, :read, Watermelon, Watermelon.visible, {}, {})
+      count = count_queries { rule.inspect }
+      expect(count).to eq 0
+    end
+  end
 end


### PR DESCRIPTION
In case of error, the dumping of all the rules could cause multiple queries on the database. This fixes the behavior by overriding the representation of the Rule object in case of inspection.
Fixes  #511