### PR TITLE
Improve usage of the rules compressor

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -68,9 +68,9 @@ appraise 'activerecord_5.2.2' do
 end
 
 appraise 'activerecord_6.0.0' do
-  gem 'actionpack', '~> 6.0.0.beta1', require: 'action_pack'
-  gem 'activerecord', '~> 6.0.0.beta1', require: 'active_record'
-  gem 'activesupport', '~> 6.0.0.beta1', require: 'active_support/all'
+  gem 'actionpack', '~> 6.0.0.beta3', require: 'action_pack'
+  gem 'activerecord', '~> 6.0.0.beta3', require: 'active_record'
+  gem 'activesupport', '~> 6.0.0.beta3', require: 'active_support/all'
 
   platforms :jruby do
     gem 'activerecord-jdbcsqlite3-adapter'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#489](https://github.com/CanCanCommunity/cancancan/pull/489): Drop support for actions without a subject. ([@andrew-aladev][])
 * [#474](https://github.com/CanCanCommunity/cancancan/pull/474): Allow to add attribute-level rules. ([@phaedryx][])
 * [#512](https://github.com/CanCanCommunity/cancancan/pull/512): Removed automatic eager loading of associations for ActiveRecord >= 5.0. ([@kaspernj][])
+* [#575](https://github.com/CanCanCommunity/cancancan/pull/575): Use the rules compressor when generating joins in accessible_by. ([@coorasse][])
 
 * [#444](https://github.com/CanCanCommunity/cancancan/issues/444): Allow to use symbols when defining conditions over enums. ([@s-mage][])
 * [#538](https://github.com/CanCanCommunity/cancancan/issues/538): Merge alias actions when merging abilities. ([@Jcambass][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * [#560](https://github.com/CanCanCommunity/cancancan/pull/560): Add support for Rails 6.0. ([@coorasse][])
 * [#489](https://github.com/CanCanCommunity/cancancan/pull/489): Drop support for actions without a subject. ([@andrew-aladev][])
 * [#474](https://github.com/CanCanCommunity/cancancan/pull/474): Allow to add attribute-level rules. ([@phaedryx][])
-* [#512](https://github.com/CanCanCommunity/cancancan/pull/512): Removed eager loading of associations for ActiveRecord >= 5.0. ([@kaspernj][])
+* [#512](https://github.com/CanCanCommunity/cancancan/pull/512): Removed automatic eager loading of associations for ActiveRecord >= 5.0. ([@kaspernj][])
 
 * [#444](https://github.com/CanCanCommunity/cancancan/issues/444): Allow to use symbols when defining conditions over enums. ([@s-mage][])
 * [#538](https://github.com/CanCanCommunity/cancancan/issues/538): Merge alias actions when merging abilities. ([@Jcambass][])

--- a/gemfiles/activerecord_6.0.0.gemfile
+++ b/gemfiles/activerecord_6.0.0.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "actionpack", "~> 6.0.0.beta1", require: "action_pack"
-gem "activerecord", "~> 6.0.0.beta1", require: "active_record"
-gem "activesupport", "~> 6.0.0.beta1", require: "active_support/all"
+gem "actionpack", "~> 6.0.0.beta3", require: "action_pack"
+gem "activerecord", "~> 6.0.0.beta3", require: "active_record"
+gem "activesupport", "~> 6.0.0.beta3", require: "active_support/all"
 
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter"

--- a/lib/cancan/model_adapters/active_record_4_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_4_adapter.rb
@@ -3,26 +3,26 @@ module CanCan
     class ActiveRecord4Adapter < ActiveRecordAdapter
       AbstractAdapter.inherited(self)
 
-      def self.for_class?(model_class)
-        version_lower?('5.0.0') && model_class <= ActiveRecord::Base
-      end
+      class << self
+        def for_class?(model_class)
+          version_lower?('5.0.0') && model_class <= ActiveRecord::Base
+        end
 
-      # TODO: this should be private
-      def self.override_condition_matching?(subject, name, _value)
-        subject.class.defined_enums.include?(name.to_s)
-      end
+        def override_condition_matching?(subject, name, _value)
+          subject.class.defined_enums.include?(name.to_s)
+        end
 
-      # TODO: this should be private
-      def self.matches_condition?(subject, name, value)
-        # Get the mapping from enum strings to values.
-        enum = subject.class.send(name.to_s.pluralize)
-        # Get the value of the attribute as an integer.
-        attribute = enum[subject.send(name)]
-        # Check to see if the value matches the condition.
-        if value.is_a?(Enumerable)
-          value.include? attribute
-        else
-          attribute == value
+        def matches_condition?(subject, name, value)
+          # Get the mapping from enum strings to values.
+          enum = subject.class.send(name.to_s.pluralize)
+          # Get the value of the attribute as an integer.
+          attribute = enum[subject.send(name)]
+          # Check to see if the value matches the condition.
+          if value.is_a?(Enumerable)
+            value.include? attribute
+          else
+            attribute == value
+          end
         end
       end
 

--- a/lib/cancan/model_adapters/active_record_5_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_5_adapter.rb
@@ -43,10 +43,7 @@ module CanCan
 
         conditions.stringify_keys!
 
-        predicate_builder
-          .build_from_hash(conditions)
-          .map { |b| visit_nodes(b) }
-          .join(' AND ')
+        predicate_builder.build_from_hash(conditions).map { |b| visit_nodes(b) }.join(' AND ')
       end
 
       def visit_nodes(node)

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -11,6 +11,11 @@ module CanCan
         Gem::Version.new(ActiveRecord.version).release < Gem::Version.new(version)
       end
 
+      def initialize(model_class, rules)
+        super
+        @compressed_rules = RulesCompressor.new(@rules.reverse).rules_collapsed.reverse
+      end
+
       # Returns conditions intended to be used inside a database query. Normally you will not call this
       # method directly, but instead go through ModelAdditions#accessible_by.
       #
@@ -27,13 +32,12 @@ module CanCan
       #   query(:manage, User).conditions # => "not (self_managed = 't') AND ((manager_id = 1) OR (id = 1))"
       #
       def conditions
-        compressed_rules = RulesCompressor.new(@rules.reverse).rules_collapsed.reverse
         conditions_extractor = ConditionsExtractor.new(@model_class)
-        if compressed_rules.size == 1 && compressed_rules.first.base_behavior
+        if @compressed_rules.size == 1 && @compressed_rules.first.base_behavior
           # Return the conditions directly if there's just one definition
-          conditions_extractor.tableize_conditions(compressed_rules.first.conditions).dup
+          conditions_extractor.tableize_conditions(@compressed_rules.first.conditions).dup
         else
-          extract_multiple_conditions(conditions_extractor, compressed_rules)
+          extract_multiple_conditions(conditions_extractor, @compressed_rules)
         end
       end
 
@@ -47,7 +51,7 @@ module CanCan
         if override_scope
           @model_class.where(nil).merge(override_scope)
         elsif @model_class.respond_to?(:where) && @model_class.respond_to?(:joins)
-          mergeable_conditions? ? build_relation(conditions) : build_relation(*@rules.map(&:conditions))
+          build_relation(conditions)
         else
           @model_class.all(conditions: conditions, joins: joins)
         end
@@ -57,7 +61,7 @@ module CanCan
       # See ModelAdditions#accessible_by
       def joins
         joins_hash = {}
-        @rules.reverse_each do |rule|
+        @compressed_rules.reverse_each do |rule|
           deep_merge(joins_hash, rule.associations_hash)
         end
         deep_clean(joins_hash) unless joins_hash.empty?
@@ -81,12 +85,8 @@ module CanCan
         end
       end
 
-      def mergeable_conditions?
-        @rules.find(&:unmergeable?).blank?
-      end
-
       def override_scope
-        conditions = @rules.map(&:conditions).compact
+        conditions = @compressed_rules.map(&:conditions).compact
         return unless conditions.any? { |c| c.is_a?(ActiveRecord::Relation) }
         return conditions.first if conditions.size == 1
 
@@ -94,7 +94,7 @@ module CanCan
       end
 
       def raise_override_scope_error
-        rule_found = @rules.detect { |rule| rule.conditions.is_a?(ActiveRecord::Relation) }
+        rule_found = @compressed_rules.detect { |rule| rule.conditions.is_a?(ActiveRecord::Relation) }
         raise Error,
               'Unable to merge an Active Record scope with other conditions. '\
               "Instead use a hash or SQL for #{rule_found.actions.first} #{rule_found.subjects.first} ability."

--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -38,18 +38,6 @@ RSpec.describe CanCan::Rule do
     expect(rule.associations_hash).to eq({})
   end
 
-  it 'is not mergeable if conditions are not simple hashes' do
-    meta_where = OpenStruct.new(name: 'metawhere', column: 'test')
-    @conditions[meta_where] = :bar
-
-    expect(@rule).to be_unmergeable
-  end
-
-  it 'is not mergeable if conditions is an empty hash' do
-    @conditions = {}
-    expect(@rule).to_not be_unmergeable
-  end
-
   it 'allows nil in attribute spot for edge cases' do
     rule1 = CanCan::Rule.new(true, :action, :subject, nil, :var)
     expect(rule1.attributes).to eq []

--- a/spec/support/sql_helpers.rb
+++ b/spec/support/sql_helpers.rb
@@ -4,6 +4,7 @@ module SQLHelpers
   end
 
   def connect_db
+    # ActiveRecord::Base.logger = Logger.new(STDOUT)
     ActiveRecord::Base.logger = nil
     if ENV['DB'] == 'sqlite'
       ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')


### PR DESCRIPTION
Different improvements:
* The RulesCompressor introduced in the previous versions can be used to reduce also the number of joins executed. This PR uses compressed rules also when generating the joins, reducing the complexity of the generated queries for `accessible_by`.
* A piece of code wrote for MetaWhere, now not supported anymore, has been removed.
* When printing a rule, the scopes are not executed
* Scopes can be compressed as well by the rules compressor
* Switch tests to Rails 6 beta3