### PR TITLE
README: Typo in Ability example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class Ability
       can :read, Post, user_id: user.id
 
       if user.admin?  # additional permissions for administrators
-        can :read, post
+        can :read, Post
       end
     end
   end


### PR DESCRIPTION
A reference to a Class seems more appropriate. Speculating this is a typo. @coorasse do you know?

This PR changes the local method call to a class name.