### PR TITLE
Prevent normalization of polymorphic association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* [#592](https://github.com/CanCanCommunity/cancancan/pull/592): Prevent normalization of through polymorphic associations.([@eloyesp][])
+
 ## 3.0.1
 
 * [#583](https://github.com/CanCanCommunity/cancancan/pull/583): Fix regression when using a method reference block. ([@coorasse][])
@@ -643,3 +645,4 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@andrew-aladev]: https://github.com/andrew-aladev
 [@phaedryx]: https://github.com/phaedryx
 [@kaspernj]: https://github.com/kaspernj
+[@eloyesp]: https://github.com/eloyesp

--- a/lib/cancan/model_adapters/conditions_normalizer.rb
+++ b/lib/cancan/model_adapters/conditions_normalizer.rb
@@ -31,13 +31,17 @@ module CanCan
             raise WrongAssociationName, "Association '#{key}' not defined in model '#{model_class.name}'"
           end
 
-          if reflection.options[:through].present?
+          if normalizable_association? reflection
             key = reflection.options[:through]
             value = { reflection.source_reflection_name => value }
             reflection = model_class.reflect_on_association(key)
           end
 
           { key => normalize_conditions(reflection.klass.name.constantize, value) }
+        end
+
+        def normalizable_association?(reflection)
+          reflection.options[:through].present? && !reflection.options[:source_type].present?
         end
       end
     end


### PR DESCRIPTION
Polymorphic associations have no klass names, so those should be not
normalized. Fixes #588.

- [x] Add tests
- [x] Changelog entry

I might need help with the tests.