### PR TITLE
`accessible_by` may crash when a `default_scope` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 3.0.2
 
 * [#590](https://github.com/CanCanCommunity/cancancan/pull/590): Fix Rule#inspect when rule is created through a SQL array. ([@frostblooded][])
-* [#592](https://github.com/CanCanCommunity/cancancan/pull/592): Prevent normalization of through polymorphic associations.([@eloyesp][])
+* [#592](https://github.com/CanCanCommunity/cancancan/pull/592): Prevent normalization of through polymorphic associations. ([@eloyesp][])
+* [#600](https://github.com/CanCanCommunity/cancancan/pull/600): Switch back to eagerly loading associations for ActiveRecord 5.0.x and 5.1.x. 5.2+ will still not automatically eager load. ([@ghiculescu][])
+* [#600](https://github.com/CanCanCommunity/cancancan/pull/600): Fix regression when using accessibl_by with default_scopes that set an order. ([@ghiculescu][])
 
 ## 3.0.1
 
@@ -650,3 +652,4 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@kaspernj]: https://github.com/kaspernj
 [@frostblooded]: https://github.com/frostblooded
 [@eloyesp]: https://github.com/eloyesp
+[@ghiculescu]: https://github.com/ghiculescu

--- a/lib/cancan/model_adapters/active_record_5_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_5_adapter.rb
@@ -43,7 +43,7 @@ module CanCan
         # this is what we do here.
         # the main downside is some queries cancan generates will now look a bit uglier.
         if need_to_extract_ids
-          @model_class.where(id: relation.reorder(nil).select(:id).distinct)
+          @model_class.where(id: relation.reorder(nil).pluck(:id).uniq)
         else
           # if we don't already have a `distinct` (relation.values[:distinct].blank?)
           # but we have added a join, we need to add our own `distinct`.

--- a/lib/cancan/model_adapters/active_record_5_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_5_adapter.rb
@@ -60,6 +60,9 @@ module CanCan
       end
 
       #### METHODS BELOW FROM kaspernj/active_record_query_fixer ####
+      # I don't expect this to get merged without more tidying up.
+
+      # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
 
       # from https://github.com/kaspernj/active_record_query_fixer/blob/master/lib/active_record_query_fixer.rb#L32
       def fix_order_select_distinct(query)
@@ -67,8 +70,9 @@ module CanCan
 
         @count_select ||= 0
         changed = false
-        query.values[:order]&.each do |order|
-          query = query.select("#{extract_table_and_column_from_expression(order)} AS active_record_query_fixer_#{@count_select}")
+        query.values[:order].each do |order|
+          select = "#{extract_table_and_column_from_expression(order)} AS active_record_query_fixer_#{@count_select}"
+          query = query.select(select)
           changed = true
           @count_select += 1
         end
@@ -91,6 +95,8 @@ module CanCan
           raise "Couldn't extract table and column from: #{order}"
         end
       end
+
+      # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 
       #### METHODS ABOVE FROM kaspernj/active_record_query_fixer ####
     end

--- a/lib/cancan/model_adapters/active_record_5_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_5_adapter.rb
@@ -43,7 +43,7 @@ module CanCan
         # this is what we do here.
         # the main downside is some queries cancan generates will now look a bit uglier.
         if need_to_extract_ids
-          @model_class.where(id: relation.reorder(nil).select("id").distinct)
+          @model_class.where(id: relation.reorder(nil).select(:id).distinct)
         else
           # if we don't already have a `distinct` (relation.values[:distinct].blank?)
           # but we have added a join, we need to add our own `distinct`.

--- a/spec/cancan/model_adapters/accessible_by_has_many_through_spec.rb
+++ b/spec/cancan/model_adapters/accessible_by_has_many_through_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CanCan::ModelAdapters::ActiveRecord5Adapter do
     end
   end
 
-  if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
+  if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
     describe 'selecting custom columns' do
       it 'extracts custom columns correctly' do
         posts = Post.accessible_by(ability).select('title as mytitle')

--- a/spec/cancan/model_adapters/accessible_by_integration_spec.rb
+++ b/spec/cancan/model_adapters/accessible_by_integration_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CanCan::ModelAdapters::ActiveRecord5Adapter do
     end
   end
 
-  if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
+  if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
     describe 'selecting custom columns' do
       it 'extracts custom columns correctly' do
         posts = Post.accessible_by(ability).select('title as mytitle')

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -82,36 +82,36 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
         end
 
         it 'can get accessible records' do
-          accessible = BlogPostComment.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1, p1c2, p1c1].map(&:body)
+          accessible = BlogPostComment.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(4)
         end
 
         it 'can get accessible records from a has_many' do
-          accessible = p2.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          accessible = p2.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many - other post' do
-          accessible = p1.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p1c2, p1c1].map(&:body)
+          accessible = p1.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many :through' do
-          accessible = alex.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          accessible = alex.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many :through - other user' do
-          accessible = josh.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p1c2, p1c1].map(&:body)
+          accessible = josh.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(2)
         end
@@ -140,36 +140,36 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
         end
 
         it 'can get accessible records' do
-          accessible = BlogPostComment.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          accessible = BlogPostComment.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many' do
-          accessible = p2.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          accessible = p2.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many - none returned' do
-          accessible = p1.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = []
+          accessible = p1.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(0)
         end
 
         it 'can get accessible records from a has_many :through' do
-          accessible = alex.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          accessible = alex.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many :through - none returned' do
-          accessible = josh.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = []
+          accessible = josh.blog_post_comments.accessible_by(ability)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
           expect(accessible.count).to eq(0)
         end

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -108,7 +108,7 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
         before do
           ability.can :read, BlogPost
           # this is the only change vs. the above context -- in this context we can *only* see alex's posts
-          ability.can :read, BlogPostComment, blog_post: { blog_author: { id: alex.id } }
+          ability.can :read, BlogPostComment, blog_post: { blog_author_id: alex.id }
         end
 
         it 'can get accessible records' do

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
+  describe CanCan::ModelAdapters::ActiveRecord5Adapter do
+    context 'with postgresql' do
+      before :each do
+        connect_db
+        ActiveRecord::Migration.verbose = false
+
+        ActiveRecord::Schema.define do
+          create_table(:blog_authors) do |t|
+            t.string :name, null: false
+            t.timestamps null: false
+          end
+
+          create_table(:blog_posts) do |t|
+            t.references :blog_author
+            t.string :title, null: false
+            t.timestamps null: false
+          end
+
+          create_table(:blog_post_comments) do |t|
+            t.references :blog_post
+            t.string :body, null: false
+            t.timestamps null: false
+          end
+        end
+
+        unless defined?(BlogAuthor)
+          class BlogAuthor < ActiveRecord::Base
+            has_many :blog_posts
+            has_many :blog_post_comments, through: :blog_posts
+          end
+        end
+
+        unless defined?(BlogPost)
+          class BlogPost < ActiveRecord::Base
+            has_many :blog_post_comments
+            belongs_to :blog_author
+
+            default_scope -> { order(:title) }
+          end
+        end
+
+        unless defined?(BlogPostComment)
+          class BlogPostComment < ActiveRecord::Base
+            belongs_to :blog_post
+
+            default_scope -> { order(created_at: :desc) }
+          end
+        end
+      end
+
+      subject(:ability) { Ability.new(nil) }
+
+      let(:alex) { BlogAuthor.create!(name: "Alex") }
+      let(:josh) { BlogAuthor.create!(name: "Josh") }
+
+      let(:p1) { josh.blog_posts.create!(title: "p1") }
+      let(:p2) { alex.blog_posts.create!(title: "p2") }
+
+      let(:p1c1) { p1.blog_post_comments.create!(body: "p1c1", created_at: Time.new(2019, 8, 25, 1)) }
+      let(:p1c2) { p1.blog_post_comments.create!(body: "p1c2", created_at: Time.new(2019, 8, 25, 2)) }
+
+      let(:p2c1) { p2.blog_post_comments.create!(body: "p2c1", created_at: Time.new(2019, 8, 25, 3)) }
+      let(:p2c2) { p2.blog_post_comments.create!(body: "p2c2", created_at: Time.new(2019, 8, 25, 4)) }
+
+      context 'when default scope sets an order, and abilities dont have extra checks' do
+        before do
+          ability.can :read, BlogPost
+          ability.can :read, BlogPostComment
+        end
+
+        it 'can get accessible records' do
+          accessible = BlogPostComment.accessible_by(ability)
+          expected_bodies_in_order = [p2c2, p2c1, p1c2, p1c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many' do
+          accessible = p2.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many - other post' do
+          accessible = p1.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = [p1c2, p1c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many :through' do
+          accessible = alex.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many :through - other user' do
+          accessible = josh.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = [p1c2, p1c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+      end
+
+      context 'when default scope sets an order, and abilities have extra checks' do
+        before do
+          ability.can :read, BlogPost
+          # this is the only change vs. the above context -- in this context we can *only* see alex's posts
+          ability.can :read, BlogPostComment, blog_post: { blog_author: { id: alex.id } }
+        end
+
+        it 'can get accessible records' do
+          accessible = BlogPostComment.accessible_by(ability)
+          expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many' do
+          accessible = p2.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many - none returned' do
+          accessible = p1.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = []
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many :through' do
+          accessible = alex.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = [p2c2, p2c1].map(&:body)
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+
+        it 'can get accessible records from a has_many :through - none returned' do
+          accessible = josh.blog_post_comments.accessible_by(ability)
+          expected_bodies_in_order = []
+          expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+        end
+      end
+    end
+  end
+end

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -55,17 +55,17 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
 
       subject(:ability) { Ability.new(nil) }
 
-      let(:alex) { BlogAuthor.create!(name: "Alex") }
-      let(:josh) { BlogAuthor.create!(name: "Josh") }
+      let(:alex) { BlogAuthor.create!(name: 'Alex') }
+      let(:josh) { BlogAuthor.create!(name: 'Josh') }
 
-      let(:p1) { josh.blog_posts.create!(title: "p1") }
-      let(:p2) { alex.blog_posts.create!(title: "p2") }
+      let(:p1) { josh.blog_posts.create!(title: 'p1') }
+      let(:p2) { alex.blog_posts.create!(title: 'p2') }
 
-      let(:p1c1) { p1.blog_post_comments.create!(body: "p1c1", created_at: Time.new(2019, 8, 25, 1)) }
-      let(:p1c2) { p1.blog_post_comments.create!(body: "p1c2", created_at: Time.new(2019, 8, 25, 2)) }
+      let(:p1c1) { p1.blog_post_comments.create!(body: 'p1c1', created_at: Time.new(2019, 8, 25, 1)) }
+      let(:p1c2) { p1.blog_post_comments.create!(body: 'p1c2', created_at: Time.new(2019, 8, 25, 2)) }
 
-      let(:p2c1) { p2.blog_post_comments.create!(body: "p2c1", created_at: Time.new(2019, 8, 25, 3)) }
-      let(:p2c2) { p2.blog_post_comments.create!(body: "p2c2", created_at: Time.new(2019, 8, 25, 4)) }
+      let(:p2c1) { p2.blog_post_comments.create!(body: 'p2c1', created_at: Time.new(2019, 8, 25, 3)) }
+      let(:p2c2) { p2.blog_post_comments.create!(body: 'p2c2', created_at: Time.new(2019, 8, 25, 4)) }
 
       context 'when default scope sets an order, and abilities dont have extra checks' do
         before do

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -77,30 +77,35 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
           accessible = BlogPostComment.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1, p1c2, p1c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(4)
         end
 
         it 'can get accessible records from a has_many' do
           accessible = p2.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many - other post' do
           accessible = p1.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p1c2, p1c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many :through' do
           accessible = alex.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many :through - other user' do
           accessible = josh.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p1c2, p1c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(2)
         end
       end
 
@@ -115,30 +120,35 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
           accessible = BlogPostComment.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many' do
           accessible = p2.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many - none returned' do
           accessible = p1.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = []
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(0)
         end
 
         it 'can get accessible records from a has_many :through' do
           accessible = alex.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = [p2c2, p2c1].map(&:body)
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(2)
         end
 
         it 'can get accessible records from a has_many :through - none returned' do
           accessible = josh.blog_post_comments.accessible_by(ability)
           expected_bodies_in_order = []
           expect(accessible.map(&:body)).to eq(expected_bodies_in_order)
+          expect(accessible.count).to eq(0)
         end
       end
     end

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -132,8 +132,7 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
             LEFT OUTER JOIN "blog_posts" ON "blog_posts"."id" = "blog_post_comments"."blog_post_id"
             WHERE "blog_posts"."blog_author_id" = 1)
             ORDER BY "blog_post_comments"."created_at" DESC
-            )
-          )
+            ))
         end
 
         it 'can get accessible records' do

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -73,14 +73,6 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
           ability.can :read, BlogPostComment
         end
 
-        if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
-          it 'generates pretty SQL' do
-            expect(ability.model_adapter(BlogPostComment, :read)).to generate_sql(%(
-              SELECT "blog_post_comments".* FROM "blog_post_comments" ORDER BY "blog_post_comments"."created_at" DESC
-            ))
-          end
-        end
-
         it 'can get accessible records' do
           expected_bodies_in_order = [p2c2, p2c1, p1c2, p1c1].map(&:body)
           accessible = BlogPostComment.accessible_by(ability)
@@ -122,21 +114,6 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
           ability.can :read, BlogPost
           # this is the only change vs. the above context -- in this context we can *only* see alex's posts
           ability.can :read, BlogPostComment, blog_post: { blog_author_id: alex.id }
-        end
-
-        if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
-          it 'generates ugly SQL' do
-            # see comments in `ActiveRecord5Adapter#extract_ids_and_requery` for why this query is so funky
-            # if this test fails because you made the query nicer... that's great. please update the test!
-            expect(ability.model_adapter(BlogPostComment, :read)).to generate_sql(%(
-              SELECT "blog_post_comments".* FROM "blog_post_comments" WHERE "blog_post_comments"."id" IN
-              (SELECT DISTINCT "blog_post_comments"."id"
-              FROM "blog_post_comments"
-              LEFT OUTER JOIN "blog_posts" ON "blog_posts"."id" = "blog_post_comments"."blog_post_id"
-              WHERE "blog_posts"."blog_author_id" = 1)
-              ORDER BY "blog_post_comments"."created_at" DESC
-              ))
-          end
         end
 
         it 'can get accessible records' do

--- a/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
+++ b/spec/cancan/model_adapters/active_record_5_adapter_with_default_scopes_spec.rb
@@ -73,10 +73,12 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
           ability.can :read, BlogPostComment
         end
 
-        it 'generates pretty SQL' do
-          expect(ability.model_adapter(BlogPostComment, :read)).to generate_sql(%(
-            SELECT "blog_post_comments".* FROM "blog_post_comments" ORDER BY "blog_post_comments"."created_at" DESC
-          ))
+        if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
+          it 'generates pretty SQL' do
+            expect(ability.model_adapter(BlogPostComment, :read)).to generate_sql(%(
+              SELECT "blog_post_comments".* FROM "blog_post_comments" ORDER BY "blog_post_comments"."created_at" DESC
+            ))
+          end
         end
 
         it 'can get accessible records' do
@@ -122,17 +124,19 @@ if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
           ability.can :read, BlogPostComment, blog_post: { blog_author_id: alex.id }
         end
 
-        it 'generates ugly SQL' do
-          # see comments in `ActiveRecord5Adapter#extract_ids_and_requery` for why this query is so funky
-          # if this test fails because you made the query nicer... that's great. please update the test!
-          expect(ability.model_adapter(BlogPostComment, :read)).to generate_sql(%(
-            SELECT "blog_post_comments".* FROM "blog_post_comments" WHERE "blog_post_comments"."id" IN
-            (SELECT DISTINCT "blog_post_comments"."id"
-            FROM "blog_post_comments"
-            LEFT OUTER JOIN "blog_posts" ON "blog_posts"."id" = "blog_post_comments"."blog_post_id"
-            WHERE "blog_posts"."blog_author_id" = 1)
-            ORDER BY "blog_post_comments"."created_at" DESC
-            ))
+        if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
+          it 'generates ugly SQL' do
+            # see comments in `ActiveRecord5Adapter#extract_ids_and_requery` for why this query is so funky
+            # if this test fails because you made the query nicer... that's great. please update the test!
+            expect(ability.model_adapter(BlogPostComment, :read)).to generate_sql(%(
+              SELECT "blog_post_comments".* FROM "blog_post_comments" WHERE "blog_post_comments"."id" IN
+              (SELECT DISTINCT "blog_post_comments"."id"
+              FROM "blog_post_comments"
+              LEFT OUTER JOIN "blog_posts" ON "blog_posts"."id" = "blog_post_comments"."blog_post_id"
+              WHERE "blog_posts"."blog_author_id" = 1)
+              ORDER BY "blog_post_comments"."created_at" DESC
+              ))
+          end
         end
 
         it 'can get accessible records' do

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -194,6 +194,7 @@ describe CanCan::ModelAdapters::ActiveRecordAdapter do
     Article.create!(published: true, category: category)
     Article.create!(published: true, category: category)
     expect(Category.accessible_by(@ability)).to match_array([category])
+    expect(Category.accessible_by(@ability).count).to eq(1)
   end
 
   it 'only reads comments for visible categories through articles' do

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -530,7 +530,8 @@ WHERE "articles"."published" = #{false_v} AND "articles"."secret" = #{true_v}))
       ability.can :read, Article, mentioned_users: { name: u1.name }
       ability.can :read, Article, mentions: { user: { name: u2.name } }
       expect(Article.accessible_by(ability)).to match_array([a1, a2])
-      if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
+
+      if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
         expect(ability.model_adapter(Article, :read)).to generate_sql(%(
   SELECT DISTINCT "articles".*
   FROM "articles"

--- a/spec/cancan/model_adapters/has_and_belongs_to_many_spec.rb
+++ b/spec/cancan/model_adapters/has_and_belongs_to_many_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe CanCan::ModelAdapters::ActiveRecord5Adapter do
       expect(houses).to match_array [@house2, @house1]
     end
 
-    if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
+    if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
       it 'generates the correct query' do
         expect(ability.model_adapter(House, :read))
           .to generate_sql("SELECT DISTINCT \"houses\".*

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'changelog' do
     expect(changelog.end_with?("\n")).to be true
   end
 
+  # if this test fails it means you probably haven't added a link
+  # for your GH username at the bottom of the CHANGELOG
   it 'has link definitions for all implicit links' do
     implicit_link_names = changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
     implicit_link_names.each do |name|


### PR DESCRIPTION
## Problem

If you have a `default_scope` that sets ordering, and define a permission that checks for records via multiple tables, and use a `has_many :through`, and run Postgres... then on version 3.x, `accessible_by` may crash. The attached test suite shows how; the tests that call `alex.blog_post_comments` fail with:

```
     ActiveRecord::StatementInvalid:
       PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
       LINE 1: ... ORDER BY "blog_post_comments"."created_at" DESC, "blog_post...

```

This regressed in https://github.com/CanCanCommunity/cancancan/pull/512

Previous query (worked fine):

```
SELECT "blog_post_comments"."id" AS t0_r0, "blog_post_comments"."blog_post_id" AS t0_r1, "blog_post_comments"."body" AS t0_r2, "blog_post_comments"."created_at" AS t0_r3, "blog_post_comments"."updated_at" AS t0_r4, "blog_posts_blog_post_comments"."id" AS t1_r0, "blog_posts_blog_post_comments"."blog_author_id" AS t1_r1, "blog_posts_blog_post_comments"."title" AS t1_r2, "blog_posts_blog_post_comments"."created_at" AS t1_r3, "blog_posts_blog_post_comments"."updated_at" AS t1_r4, "blog_authors"."id" AS t2_r0, "blog_authors"."name" AS t2_r1, "blog_authors"."created_at" AS t2_r2, "blog_authors"."updated_at" AS t2_r3 FROM "blog_post_comments" LEFT OUTER JOIN "blog_posts" "blog_posts_blog_post_comments" ON "blog_posts_blog_post_comments"."id" = "blog_post_comments"."blog_post_id" LEFT OUTER JOIN "blog_authors" ON "blog_authors"."id" = "blog_posts_blog_post_comments"."blog_author_id" INNER JOIN "blog_posts" ON "blog_post_comments"."blog_post_id" = "blog_posts"."id" WHERE "blog_posts"."blog_author_id" = 1 AND "blog_authors"."id" = 1 ORDER BY "blog_post_comments"."created_at" DESC, "blog_posts"."title" ASC
```

New query (crashes):

```
SELECT DISTINCT "blog_post_comments".* FROM "blog_post_comments" INNER JOIN "blog_posts" ON "blog_post_comments"."blog_post_id" = "blog_posts"."id" LEFT OUTER JOIN "blog_posts" "blog_posts_blog_post_comments" ON "blog_posts_blog_post_comments"."id" = "blog_post_comments"."blog_post_id" LEFT OUTER JOIN "blog_authors" ON "blog_authors"."id" = "blog_posts_blog_post_comments"."blog_author_id" WHERE "blog_posts"."blog_author_id" = 1 AND "blog_authors"."id" = 1 ORDER BY "blog_post_comments"."created_at" DESC, "blog_posts"."title" ASC
```

After writing this up I realised there was a much simpler replication case reported here: https://github.com/CanCanCommunity/cancancan/pull/508#issuecomment-399851657

Also I know that this is mentioned in the [updating notes](https://github.com/CanCanCommunity/cancancan/wiki/Migrating-from-CanCanCan-2.x-to-3.0) but in my opinion cancancan should be able to handle this for the user.

-----------------

## Solution

Okay so I kind of hate this PR _but_ I haven't found a better solution. There's a few things going on here.

- [`add_joins_to_relation`](https://github.com/CanCanCommunity/cancancan/pull/600/files#diff-630cf3395cf508b3ec775deb809cbf6fR55). `Relation#left_joins` does not work super well in AR 5.0 and 5.1; it's failing on a bunch of the tests added in this PR. Thus I'm not using it for older Rails versions; for those I'm falling back to how joins worked before #512.
- [`extract_ids_and_requery`](https://github.com/CanCanCommunity/cancancan/pull/600/files#diff-630cf3395cf508b3ec775deb809cbf6fR33) has like a million comments explaining what it does. It means we'll be running an extra query fairly often so I'm keen for feedback on if this is actually worth doing.

Basically I hate this solution but I can't find another way of getting it to work if we keep `left_joins`. And if we ditch `left_joins`, there's still things that don't work. For example, there's some tests that do `Post.accessible_by(ability).select('title as mytitle')` that *only* work if you use `left_joins` (they were introduced after #512).