### PR TITLE
Implement negative expectation handler logic for `be_able_to` matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.2
 
+* [#505](https://github.com/CanCanCommunity/cancancan/issues/505): Implement negative expectation handler logic for `be_able_to` matcher. ([@stowersjoshua][])
 * [#590](https://github.com/CanCanCommunity/cancancan/pull/590): Fix Rule#inspect when rule is created through a SQL array. ([@frostblooded][])
 * [#592](https://github.com/CanCanCommunity/cancancan/pull/592): Prevent normalization of through polymorphic associations.([@eloyesp][])
 
@@ -650,3 +651,4 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@kaspernj]: https://github.com/kaspernj
 [@frostblooded]: https://github.com/frostblooded
 [@eloyesp]: https://github.com/eloyesp
+[@stowersjoshua]: https://github.com/stowersjoshua

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -21,6 +21,17 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
     end
   end
 
+  match_when_negated do |ability|
+    actions = args.first
+    if actions.is_a? Array
+      break false if actions.empty?
+
+      actions.all? { |action| ability.cannot?(action, *args[1..-1]) }
+    else
+      ability.cannot?(*args)
+    end
+  end
+
   # Check that RSpec is < 2.99
   if !respond_to?(:failure_message) && respond_to?(:failure_message_for_should)
     alias_method :failure_message, :failure_message_for_should

--- a/spec/cancan/matchers_spec.rb
+++ b/spec/cancan/matchers_spec.rb
@@ -5,54 +5,121 @@ require 'spec_helper'
 describe 'be_able_to' do
   subject { double }
 
-  context 'check single ability' do
-    it 'delegates to can?' do
-      is_expected.to receive(:can?).with(:read, 123) { true }
-      is_expected.to be_able_to(:read, 123)
+  context 'when expecting to match' do
+    context 'check single ability' do
+      it 'delegates to can?' do
+        is_expected.to receive(:can?).with(:read, 123) { true }
+
+        result = be_able_to([:read], 123).matches?(subject)
+        expect(result).to eq(true)
+      end
+
+      it 'reports a nice failure message' do
+        is_expected.to receive(:can?).with(:read, 123) { false }
+
+        expect do
+          is_expected.to be_able_to(:read, 123)
+        end.to raise_error('expected to be able to :read 123')
+      end
+
+      it 'delegates additional arguments to can? and reports a failure message' do
+        is_expected.to receive(:can?).with(:read, 123, 456) { false }
+
+        expect do
+          is_expected.to be_able_to(:read, 123, 456)
+        end.to raise_error('expected to be able to :read 123 456')
+      end
     end
 
-    it 'reports a nice failure message for should' do
-      is_expected.to receive(:can?).with(:read, 123) { false }
-      expect do
-        is_expected.to be_able_to(:read, 123)
-      end.to raise_error('expected to be able to :read 123')
-    end
+    context 'check array of abilities' do
+      it 'delegates to can? with array of abilities with one action' do
+        is_expected.to receive(:can?).with(:read, 123) { true }
 
-    it 'reports a nice failure message for should not' do
-      is_expected.to receive(:can?).with(:read, 123) { true }
-      expect do
-        is_expected.to_not be_able_to(:read, 123)
-      end.to raise_error('expected not to be able to :read 123')
-    end
+        result = be_able_to([:read], 123).matches?(subject)
+        expect(result).to eq(true)
+      end
 
-    it 'delegates additional arguments to can? and reports in failure message' do
-      is_expected.to receive(:can?).with(:read, 123, 456) { false }
-      expect do
-        is_expected.to be_able_to(:read, 123, 456)
-      end.to raise_error('expected to be able to :read 123 456')
+      it 'delegates to can? with array of abilities with multiple actions' do
+        is_expected.to receive(:can?).with(:read, 123) { true }
+        is_expected.to receive(:can?).with(:update, 123) { true }
+
+        result = be_able_to(%i[read update], 123).matches?(subject)
+        expect(result).to eq(true)
+      end
+
+      it 'does not delegate to can? with empty array of abilities' do
+        is_expected.not_to receive(:can?)
+
+        result = be_able_to([], 123).matches?(subject)
+        expect(result).to eq(false)
+      end
+
+      it 'delegates to can? with array of abilities with only one eligable ability' do
+        is_expected.to receive(:can?).with(:read, 123) { true }
+        is_expected.to receive(:can?).with(:update, 123) { false }
+
+        result = be_able_to(%i[read update], 123).matches?(subject)
+        expect(result).to eq(false)
+      end
     end
   end
 
-  context 'check array of abilities' do
-    it 'delegates to can? with array of abilities with one action' do
-      is_expected.to receive(:can?).with(:read, 123) { true }
-      is_expected.to be_able_to([:read], 123)
+  context 'when expecting not to match' do
+    context 'check single ability' do
+      it 'delegates to cannot?' do
+        is_expected.to receive(:cannot?).with(:read, 123) { true }
+
+        result = be_able_to([:read], 123).does_not_match?(subject)
+        expect(result).to eq(true)
+      end
+
+      it 'reports a nice failure message' do
+        is_expected.to receive(:cannot?).with(:read, 123) { false }
+
+        expect do
+          is_expected.not_to be_able_to(:read, 123)
+        end.to raise_error('expected not to be able to :read 123')
+      end
+
+      it 'delegates additional arguments to can? and reports a failure message' do
+        is_expected.to receive(:cannot?).with(:read, 123, 456) { false }
+
+        expect do
+          is_expected.not_to be_able_to(:read, 123, 456)
+        end.to raise_error('expected not to be able to :read 123 456')
+      end
     end
 
-    it 'delegates to can? with array of abilities with multiple actions' do
-      is_expected.to receive(:can?).with(:read, 123) { true }
-      is_expected.to receive(:can?).with(:update, 123) { true }
-      is_expected.to be_able_to(%i[read update], 123)
-    end
+    context 'check array of abilities' do
+      it 'delegates to cannot? with array of abilities with one action' do
+        is_expected.to receive(:cannot?).with(:read, 123) { true }
 
-    it 'delegates to can? with array of abilities with empty array' do
-      is_expected.not_to be_able_to([], 123)
-    end
+        result = be_able_to([:read], 123).does_not_match?(subject)
+        expect(result).to eq(true)
+      end
 
-    it 'delegates to can? with array of abilities with only one eligable ability' do
-      is_expected.to receive(:can?).with(:read, 123) { true }
-      is_expected.to receive(:can?).with(:update, 123) { false }
-      is_expected.not_to be_able_to(%i[read update], 123)
+      it 'delegates to cannot? with array of abilities with multiple actions' do
+        is_expected.to receive(:cannot?).with(:read, 123) { true }
+        is_expected.to receive(:cannot?).with(:update, 123) { true }
+
+        result = be_able_to(%i[read update], 123).does_not_match?(subject)
+        expect(result).to eq(true)
+      end
+
+      it 'does not delegate to cannot? with empty array of abilities' do
+        is_expected.not_to receive(:cannot?)
+
+        result = be_able_to([], 123).does_not_match?(subject)
+        expect(result).to eq(false)
+      end
+
+      it 'delegates to cannot? with array of abilities with only one ineligable ability' do
+        is_expected.to receive(:cannot?).with(:read, 123) { false }
+        is_expected.to receive(:cannot?).with(:update, 123) { true }
+
+        result = be_able_to(%i[update read], 123).does_not_match?(subject)
+        expect(result).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
The [original issue](https://github.com/CanCanCommunity/cancancan/issues/505) has already been closed. Please see my [rationale](#rationale) below.

- [x] Add tests
- [x] Changelog entry

---

Updates `be_able_to` matcher with a negative expectation handler. 

Now, if you pass an array of abilities while using `not_to`, the expectation will fail if **any** of the specified abilities turn out to be permitted.

Previously, the following test would pass, despite the user only being able to `:read` posts.

```ruby
it { is_expected.not_to be_able_to [:create, :read], Post }

...

class Ability
  include CanCan::Ability

  def initialize(_user)
    can :read, Post
  end
end
```

# Rationale
The matcher's current behavior when handling negative expectations is unlikely to be useful in many situations. Because its behavior is unexpected, it is easy to accidentally write tests that _look_ like they'll work, but then unexpectedly pass. This can be very dangerous if a developer doesn't realize how the matcher actually behaves when initially implementing the test.

The next best approach to confirm that an ability cannot be used would be to iterate over an array of abilities and test them individually. This is a bit verbose and difficult to read - especially compared to the awesome one-liner already provided.

