### PR TITLE
Suppress keyword arguments warning for Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.4.2
   - 2.5.1
   - 2.6.3
+  - 2.7.0
   - ruby-head
   - jruby-9.1.17.0
   - jruby-9.2.7.0
@@ -32,6 +33,8 @@ matrix:
     gemfile: gemfiles/activerecord_6.0.0.gemfile
   - rvm: 2.4.2
     gemfile: gemfiles/activerecord_6.0.0.gemfile
+  - rvm: 2.7.0
+    gemfile: gemfiles/activerecord_4.2.0.gemfile
   - rvm: jruby-9.1.17.0
     gemfile: gemfiles/activerecord_5.0.2.gemfile
   - rvm: jruby-9.1.17.0

--- a/lib/cancan/unauthorized_message_resolver.rb
+++ b/lib/cancan/unauthorized_message_resolver.rb
@@ -6,7 +6,7 @@ module CanCan
       keys = unauthorized_message_keys(action, subject)
       variables = { action: action.to_s }
       variables[:subject] = translate_subject(subject)
-      message = I18n.translate(keys.shift, variables.merge(scope: :unauthorized, default: keys + ['']))
+      message = I18n.translate(keys.shift, **variables.merge(scope: :unauthorized, default: keys + ['']))
       message.blank? ? nil : message
     end
 


### PR DESCRIPTION
## Summary

This PR suppresses the following keyword arguments warning for Ruby 2.7.0.

```console
% ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin17]
% DB=sqlite bundle exec appraisal activerecord_6.0.0 rake

/Users/koic/src/github.com/CanCanCommunity/cancancan/lib/cancan/unauthorized_message_resolver.rb:9:
warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
/Users/koic/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/i18n-1.8.0/lib/i18n.rb:195:
warning: The called method `translate' is defined here
```

For Ruby 2.8.0-dev (Ruby 3.0) the warning will be `ArgumentError`.
https://github.com/ruby/ruby/pull/2794

## Other Infromation

There are other similar warnings against Active Record, but Rails 6.0 stable branch is WIP.
https://github.com/rails/rails/pull/37935

It is not subject to changes in this repository.