### PR TITLE
Add support for using an empty array as a condition

### DIFF
--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -70,7 +70,11 @@ module CanCan
       when Range
         value.cover?(attribute)
       when Enumerable
-        value.include?(attribute)
+        if attribute.size == 0 # if we expect an empty array, return true if we are given one
+          value.size == 0
+        else
+          value.include?(attribute)
+        end
       else
         attribute == value
       end


### PR DESCRIPTION
I want to define an ability check that only applies if a `has_many` relation returns an empty array. The use case is I want to only allow deleting a record if it has no associated records for a given association.

This PR implements that functionality. Note that it only works for `can?` checks, not `accessible_by`; there's a comment explaining why. I'd like to add a warning to https://github.com/CanCanCommunity/cancancan/wiki/defining-abilities that explains this too if this is approved.