### PR TITLE
Add: wiki documentation into a separate docs folder

### DIFF
--- a/docs/Abilities-in-Database.md
+++ b/docs/Abilities-in-Database.md
@@ -1,0 +1,124 @@
+What if you or a client, wants to change permissions without having to re-deploy the application? 
+In that case, it may be best to store the permission logic in a database: it is very easy to use the database records when defining abilities.
+
+We will need a model called `Permission`. 
+
+Each user `has_many :permissions`, and each permission has `action`, `subject_class` and `subject_id` columns. The last of which is optional.
+
+```ruby
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can do |action, subject_class, subject|
+      user.permissions.where(action: aliases_for_action(action)).any? do |permission|
+        permission.subject_class == subject_class.to_s &&
+          (subject.nil? || permission.subject_id.nil? || permission.subject_id == subject.id)
+      end
+    end
+  end
+end
+```
+
+An alternative approach is to define a separate `can` ability for each permission.
+
+```ruby
+def initialize(user)
+  user.permissions.each do |permission|
+    if permission.subject_id.nil?
+      can permission.action.to_sym, permission.subject_class.constantize
+    else
+      can permission.action.to_sym, permission.subject_class.constantize, id: permission.subject_id
+    end
+  end
+end
+```
+
+The actual details will depend largely on your application requirements, but hopefully, you can see how it's possible to define permissions in the database and use them with CanCanCan.
+
+You can mix-and-match this with defining permissions in the code as well. This way you can keep the more complex logic in the code so you don't need to shoe-horn every kind of permission rule into an overly-abstract database.
+
+
+You can also create a `Permission` model containing all possible permissions in your app. Use that code to create a rake task that fills a `Permission` table:
+(The code below is not fully tested)
+
+To use the following code, the permissions table should have such fields :name, :user_id, :subject_class, :subject_id, :action, and :description.You can generate the permission model by the command: `rails g model Permission user_id:integer name:string subject_class:string subject_id:integer action:string description:text`.
+
+```ruby
+class ApplicationController < ActionController::Base
+  ...
+  protected
+
+  # Derive the model name from the controller. UsersController will return User
+  def self.permission
+    return name = controller_name.classify.constantize
+  end
+end
+```
+
+```ruby
+def setup_actions_controllers_db
+
+  write_permission("all", "manage", "Everything", "All operations", true)
+
+  controllers = Dir.new("#{Rails.root}/app/controllers").entries
+  controllers.each do |controller|
+    if controller =~ /_controller/
+      foo_bar = controller.camelize.gsub(".rb","").constantize.new
+    end
+  end
+  # You can change ApplicationController for a super-class used by your restricted controllers
+  ApplicationController.subclasses.each do |controller|
+    if controller.respond_to?(:permission)	
+      klass, description = controller.permission
+      write_permission(klass, "manage", description, "All operations")
+      controller.action_methods.each do |action|
+        if action.to_s.index("_callback").nil?
+          action_desc, cancan_action = eval_cancan_action(action)
+          write_permission(klass, cancan_action, description, action_desc)
+        end
+      end
+    end
+  end
+	
+end
+
+
+def eval_cancan_action(action)
+  case action.to_s
+  when "index", "show", "search"
+    cancan_action = "read"
+    action_desc = I18n.t :read
+  when "create", "new"
+    cancan_action = "create"
+    action_desc = I18n.t :create
+  when "edit", "update"
+    cancan_action = "update"
+    action_desc = I18n.t :edit
+  when "delete", "destroy"
+    cancan_action = "delete"
+    action_desc = I18n.t :delete
+  else
+    cancan_action = action.to_s
+    action_desc = "Other: " << cancan_action
+  end
+  return action_desc, cancan_action
+end
+
+def write_permission(class_name, cancan_action, name, description, force_id_1 = false)
+  permission  = Permission.find(:first, :conditions => ["subject_class = ? and action = ?", class_name, cancan_action]) 
+  if not permission
+    permission = Permission.new
+    permission.id = 1 if force_id_1
+    permission.subject_class =  class_name
+    permission.action = cancan_action
+    permission.name = name
+    permission.description = description
+    permission.save
+  else
+    permission.name = name
+    permission.description = description
+    permission.save
+  end
+end
+```

--- a/docs/Ability-Precedence.md
+++ b/docs/Ability-Precedence.md
@@ -1,0 +1,47 @@
+An ability rule will override a previous one. 
+For example, let's say we want the user to be able to do everything to projects except destroy them. 
+
+This is the correct way:
+
+```ruby
+can :manage, Project
+cannot :destroy, Project
+```
+
+It is important that the `cannot :destroy` line comes after the `can :manage` line. If they were reversed, `cannot :destroy` would be overridden by `can :manage`.
+
+Adding `can` rules do not override prior rules, but instead are logically or'ed.
+
+```ruby
+can :manage, Project, user_id: user.id
+can :update, Project do |project|
+  !project.locked?
+end
+```
+
+For the above, `can? :update` will always return true if the `user_id` equals `user.id`, even if the project is locked. 
+
+This is also important when dealing with roles which have inherited behavior. For example, let's say we have two roles, moderator and admin. We want the admin to inherit the moderator's behavior.
+
+```ruby
+if user.role? :moderator
+  can :manage, Project
+  cannot :destroy, Project
+  can :manage, Comment
+end
+
+if user.role? :admin
+  can :destroy, Project
+end
+```
+
+Here it is important the admin role be after the moderator so it can override the `cannot` behavior to give the admin more permissions. See [[Role Based Authorization]].
+
+If you are not getting the behavior you expect, please [[post an issue|https://github.com/CanCanCommunity/cancancan/issues]].
+
+## Additional Docs
+
+* [[Defining Abilities]]
+* [[Checking Abilities]]
+* [[Debugging Abilities]]
+* [[Testing Abilities]]

--- a/docs/Ability-for-Other-Users.md
+++ b/docs/Ability-for-Other-Users.md
@@ -1,0 +1,34 @@
+What if you want to determine the abilities of a `User` record that is not the `current_user`? Maybe we want to see if another user can update an article.
+
+```ruby
+some_user.ability.can? :update, @article
+```
+
+You can easily add an `ability` method in the `User` model.
+
+```ruby
+def ability
+  @ability ||= Ability.new(self)
+end
+```
+
+I also recommend adding delegation so `can?` can be called directly from the user.
+
+```ruby
+class User < ActiveRecord::Base
+  delegate :can?, :cannot?, to: :ability
+  # ...
+end
+
+some_user.can? :update, @article
+```
+
+Finally, if you're using this approach, it's best to override the `current_ability` method in the `ApplicationController` so it uses the same method.
+
+```ruby
+def current_ability
+  @current_ability ||= current_user.ability
+end
+```
+
+The downside of this approach is that [[Accessing Request Data]] is not as easy, so it depends on the needs of your application.

--- a/docs/Accessing-request-data.md
+++ b/docs/Accessing-request-data.md
@@ -1,0 +1,25 @@
+What if you need to modify the permissions based on something outside of the User object? For example, let's say you want to blacklist certain IP addresses from creating comments. The IP address is accessible through request.remote_ip but the Ability class does not have access to this. It's easy to modify what you pass to the Ability object by overriding the current_ability method in ApplicationController.
+
+```ruby
+class ApplicationController < ActionController::Base
+  #...
+
+  private
+
+  def current_ability
+    @current_ability ||= Ability.new(current_user, request.remote_ip)
+  end
+end
+```
+```ruby
+class Ability
+  include CanCan::Ability
+
+  def initialize(user, ip_address=nil)
+    can :create, Comment unless BLACKLIST_IPS.include? ip_address
+  end
+end
+```
+This concept can apply to session and cookies as well.
+
+You may wonder, why I pass only the IP Address instead of the entire request object? I prefer to pass only the information needed, this makes testing and debugging the behavior easier.

--- a/docs/Action-Aliases.md
+++ b/docs/Action-Aliases.md
@@ -1,0 +1,32 @@
+You will usually be working with four actions when [[defining|Defining Abilities]] and [[checking|Checking Abilities]] permissions: `:read`, `:create`, `:update`, `:destroy`. These aren't the same as the 7 RESTful actions in Rails. CanCanCan automatically adds some convenient aliases for mapping the controller actions.
+
+```ruby
+alias_action :index, :show, :to => :read
+alias_action :new, :to => :create
+alias_action :edit, :to => :update
+```
+
+Notice the `edit` action is aliased to `update`. This means if the user is able to update a record he also has permission to edit it. You can define your own aliases in the `Ability` class.
+
+```ruby
+class Ability
+  include CanCan::Ability
+  def initialize(user)
+    alias_action :update, :destroy, :to => :modify
+    can :modify, Comment
+  end
+end
+
+# in controller or view
+can? :update, Comment # => true
+```
+
+You are not restricted to just the 7 RESTful actions, you can use any action name. See [[Custom Actions]] for details.
+
+Please note that if you are changing the default alias_actions, the original actions associated with the alias will NOT be removed.  For example, following statement will not have any effect on the alias :read, which points to :show and :index:
+
+```ruby
+alias_action :show, :to => :read # this will have no effect on the alias :read!
+```
+
+If you want to change the default actions, you should use clear_aliased_actions method to remove ALL default aliases first.

--- a/docs/Authorization-for-Namespaced-Controllers.md
+++ b/docs/Authorization-for-Namespaced-Controllers.md
@@ -1,0 +1,51 @@
+The default operation for CanCanCan is to authorize based on user and the object identified in `load_resource`.  So if you have a `WidgetsController` and also an `Admin::WidgetsController`, you can use some different approaches.
+
+Just like in the example given for [[Accessing Request Data]], you **can** also create differing authorization rules that depend on the controller namespace.  
+
+In this case, just override the `current_ability` method in `ApplicationController` to include the controller namespace, and create an `Ability` class that knows what to do with it.
+
+``` ruby
+class Admin::WidgetsController < ActionController::Base
+  #...
+
+  private
+
+  def current_ability
+    # I am sure there is a slicker way to capture the controller namespace
+    controller_name_segments = params[:controller].split('/')
+    controller_name_segments.pop
+    controller_namespace = controller_name_segments.join('/').camelize
+    @current_ability ||= Ability.new(current_user, controller_namespace)
+  end
+end
+
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user, controller_namespace)
+    case controller_namespace
+      when 'Admin'
+        can :manage, :all if user.has_role? 'admin'
+      else
+        # rules for non-admin controllers here
+    end
+  end
+end
+```
+
+Another way to achieve the same is to use a completely different Ability class in this controller:
+
+``` ruby
+class Admin::WidgetsController < ActionController::Base
+  #...
+
+  private
+
+  def current_ability
+    @current_ability ||= AdminAbility.new(current_user)
+  end
+end
+```
+
+and follow the [Best Practice of splitting your Ability file into multiple files](https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities%3A-Best-Practices#split-your-abilityrb-file).

--- a/docs/Authorizing-controller-actions.md
+++ b/docs/Authorizing-controller-actions.md
@@ -1,0 +1,210 @@
+You can use the `authorize!` method to manually handle authorization in a controller action. This will raise a `CanCan::AccessDenied` exception when the user does not have permission. See [[Exception Handling]] for how to react to this.
+
+```ruby
+def show
+  @project = Project.find(params[:project])
+  authorize! :show, @project
+end
+```
+
+However that can be tedious to apply to each action. Instead you can use the `load_and_authorize_resource` method in your controller to load the resource into an instance variable and authorize it automatically for every action in that controller.
+
+```ruby
+class ProductsController < ActionController::Base
+  load_and_authorize_resource
+end
+```
+
+This is the same as calling `load_resource` and `authorize_resource` because they are two separate steps and you can choose to use one or the other.
+
+```ruby
+class ProductsController < ActionController::Base
+  load_resource
+  authorize_resource
+end
+```
+
+As of CanCan 1.5 you can use the `skip_load_and_authorize_resource`, `skip_load_resource` or `skip_authorize_resource` methods to skip any of the applied behavior and specify specific actions like in a before filter. For example.
+
+```ruby
+class ProductsController < ActionController::Base
+  load_and_authorize_resource
+  skip_authorize_resource :only => :new
+end
+```
+
+**important notice about `:manage` rules**
+
+Using `load_and_authorize_resource` with a rule like `can :manage, Article, id: 23` will allow rendering the `new` method of the ArticlesController, which is unexpected because this rule naively reads as _"the user can manage the existing article with id 23"_, which should have nothing to do with creating new articles.
+
+But in reality the rule means _"the user can manage any article object with an id field set to 23"_, which includes creating a new Article with the id set to 23 like `Article.new(id: 23)`.
+
+Thus `load_and_authorize_resource` will initialize a model in the `:new` action and set its id to 23, and happily render the page. Saving will not work though.
+
+The correct intended rule to avoid `new` being allowed would be:
+
+``` ruby
+can [:read, :update, :destroy], Article, id: 23
+```
+
+Also see [[Controller Authorization Example]], [[Ensure Authorization]] and [[Non RESTful Controllers]].
+
+
+## Choosing Actions
+
+By default this will apply to **every action** in the controller even if it is not one of the 7 RESTful actions. The action name will be passed in when authorizing. For example, if we have a `discontinue` action on `ProductsController` it will have this behavior.
+
+```ruby
+class ProductsController < ActionController::Base
+  load_and_authorize_resource
+  def discontinue
+    # Automatically does the following:
+    # @product = Product.find(params[:id])
+    # authorize! :discontinue, @product
+  end
+end
+```
+
+You can specify which actions to affect using the `:except` and `:only` options, just like a `before_action`.
+
+```ruby
+load_and_authorize_resource :only => [:index, :show]
+```
+### Choosing actions on nested resources 
+
+For this you can pass a name to skip_authorize_resource.
+For example:
+```ruby
+class CommentsController < ApplicationController
+  load_and_authorize_resource :post
+  load_and_authorize_resource :through => :post
+
+  skip_authorize_resource :only => :show  
+  skip_authorize_resource :post, :only => :show
+end
+```
+
+The first skip_authorize_resource skips authorization check for comment and the second for post. Both are needed if you want to skip all authorization checks for an action.
+
+## load_resource
+
+### index action
+
+As of 1.4 the index action will load the collection resource using `accessible_by`.
+
+```ruby
+def index
+  # @products automatically set to Product.accessible_by(current_ability)
+end
+```
+
+If you want custom find options such as [[includes|https://github.com/ryanb/cancan/issues#issue/259]] or pagination, you can build on this further since it is a scope.
+
+```ruby
+def index
+  @products = @products.includes(:category).page(params[:page])
+end
+```
+
+The `@products` variable will not be set initially if `Product` does not respond to `accessible_by` (such as if you aren't using a supported ORM). It will also not be set if you are only using a block in the `can` definitions because there is no way to determine which records to fetch from the database.
+
+### show, edit, update and destroy actions
+
+These member actions simply fetch the record directly.
+
+```ruby
+def show
+  # @product automatically set to Product.find(params[:id])
+end
+```
+
+### new and create actions
+
+As of 1.4 these builder actions will initialize the resource with the attributes in the hash conditions. For example, if we have this `can` definition.
+
+```ruby
+can :manage, Product, :discontinued => false
+```
+
+Then the product will be built with that attribute in the controller.
+
+```ruby
+@product = Product.new(:discontinued => false)
+```
+
+This way it will pass authorization when the user accesses the `new` action.
+
+The attributes are then overridden by whatever is passed by the user in `params[:product]`.
+
+### Custom class
+
+If the model is named differently than the controller, then you may explicitly name the model that should be loaded; however, you must specify that it is not a parent in a nested routing situation, ie:
+
+```ruby
+class ArticlesController < ApplicationController
+  load_and_authorize_resource :post, :parent => false
+end
+```
+
+If the model class is namespaced differently than the controller you will need to specify the `:class` option.
+
+```ruby
+class ProductsController < ApplicationController
+  load_and_authorize_resource :class => "Store::Product"
+end
+```
+
+
+### Custom find
+
+If you want to fetch a resource by something other than `id` it can be done so using the `find_by` option.
+
+```ruby
+load_resource :find_by => :permalink # will use find_by_permalink!(params[:id])
+authorize_resource
+```
+
+### Override loading
+
+The resource will only be loaded into an instance variable if it hasn't been already. This allows you to easily override how the loading happens in a separate `before_action`.
+
+```ruby
+class BooksController < ApplicationController
+  before_action :find_published_book, :only => :show
+  load_and_authorize_resource
+
+  private
+
+  def find_published_book
+    @book = Book.released.find(params[:id])
+  end
+end
+```
+
+It is important that any custom loading behavior happens **before** the call to `load_and_authorize_resource`. If you have `authorize_resource` in your `ApplicationController` then you need to use `prepend_before_action` to do the loading in the controller subclasses so it happens before authorization.
+
+## authorize_resource
+
+Adding `authorize_resource` will install a `before_action` callback that calls `authorize!`, passing the resource instance variable if it exists. If the instance variable isn't set (such as in the index action) it will pass in the class name. For example, if we have a `ProductsController` it will do this before each action.
+
+```ruby
+authorize!(params[:action].to_sym, @product || Product)
+```
+
+## More info
+
+For additional information see the `load_resource` and `authorize_resource` methods in the [[RDoc|http://www.rubydoc.info/github/CanCanCommunity/cancancan]].
+
+Also see [[Nested Resources]] and [[Non RESTful Controllers]].
+
+## Resetting Current Ability
+
+If you ever update a User record which may be the current user, it will make the current ability for that request stale. This means any `can?` checks will use the user record before it was updated. You will need to reset the `current_ability` instance so it will be reloaded. Do the same for the `current_user` if you are caching that too.
+
+```ruby
+if @user.update_attributes(params[:user])
+  @current_ability = nil
+  @current_user = nil
+  # ...
+end
+```

--- a/docs/Changing-Defaults.md
+++ b/docs/Changing-Defaults.md
@@ -1,0 +1,44 @@
+CanCanCan makes two assumptions about your application.
+
+* You have an `Ability` class which defines the permissions.
+* You have a `current_user` method in the controller which returns the current user model.
+
+You can override both of these by defining the `current_ability` method in your `ApplicationController`. The current method looks like this.
+
+```ruby
+def current_ability
+  @current_ability ||= Ability.new(current_user)
+end
+```
+
+The `Ability` class and `current_user` method can easily be changed to something else.
+
+```ruby
+# in ApplicationController
+def current_ability
+  @current_ability ||= AccountAbility.new(current_account)
+end
+```
+
+Sometimes you might have a gem in your project which provides its own Rails engine which also uses CanCanCan such as LocomotiveCMS. In this case the current_ability override in the ApplicationController can also be useful.
+
+```ruby
+# in ApplicationController
+def current_ability
+  if request.fullpath =~ /\/locomotive/
+    @current_ability ||= Locomotive::Ability.new(current_user)
+  else
+    @current_ability ||= Ability.new(current_user)
+  end
+end
+```
+
+If your method that returns the currently logged in user just has another name than `current_user`, it may be the easiest solution to simply alias the method in your ApplicationController like this:
+
+```ruby
+class ApplicationController < ActionController::Base
+  alias_method :current_user, :name_of_your_method # Could be :current_member or :logged_in_user
+end
+```
+
+That's it! See [[Accessing Request Data]] for a more complex example of what you can do here.

--- a/docs/Checking-Abilities.md
+++ b/docs/Checking-Abilities.md
@@ -1,0 +1,51 @@
+After [[abilities are defined|Defining Abilities]], you can use the `can?` method in the controller or view to check the user's permission for a given action and object.
+
+```ruby
+can? :destroy, @project
+```
+
+The `cannot?` method is for convenience and performs the opposite check of `can?`
+
+```ruby
+cannot? :destroy, @project
+```
+
+Also see [[Authorizing Controller Actions]] and  [[Custom Actions]].
+
+## Checking with Class
+
+You can also pass the class instead of an instance (if you don't have one handy).
+
+```rhtml
+<% if can? :create, Project %>
+  <%= link_to "New Project", new_project_path %>
+<% end %>
+```
+
+**Important:** If a block or hash of conditions exist they will be ignored when checking on a class, and it will return `true`. For example:
+
+```ruby
+can :read, Project, :priority => 3
+can? :read, Project # returns true
+```
+
+It is impossible to answer this `can?` question completely because not enough detail is given. Here the class does not have a `priority` attribute to check on.
+
+Think of it as asking "can the current user read **a** project?". The user can read a project, so this returns `true`. However it depends on which specific project you're talking about. If you are doing a class check, it is important you do another check once an instance becomes available so the hash of conditions can be used.
+
+The reason for this behavior is because of the controller `index` action. Since the `authorize_resource` before filter has no instance to check on, it will use the `Project` class. If the authorization failed at that point then it would be impossible to filter the results later when [[Fetching Records]].
+
+That is why passing a class to `can?` will return `true`.
+
+The code answering the question "can the user update all the articles?" would be something like:
+
+``` ruby
+Article.accessible_by(current_ability).count == Article.count
+```
+
+## Additional Docs
+
+* [[Defining Abilities]]
+* [[Ability Precedence]]
+* [[Debugging Abilities]]
+* [[Testing Abilities]]

--- a/docs/Controller-Authorization-Example.md
+++ b/docs/Controller-Authorization-Example.md
@@ -1,0 +1,70 @@
+CanCan provides a convenient `load_and_authorize_resource` method in the controller, but what exactly is this doing? It sets up a before filter for every action to handle the loading and authorization of the controller. Let's say we have a typical RESTful controller with that line at the top.
+
+```ruby
+class ProjectsController < ApplicationController
+  load_and_authorize_resource
+  # ...
+end
+```
+
+It will add a before filter that has this behavior for the actions if they exist. This means you do not need to put code below in your controller.
+
+```ruby
+class ProjectsController < ApplicationController
+  def index
+    authorize! :index, Project
+    @projects = Project.accessible_by(current_ability)
+  end
+
+  def show
+    @project = Project.find(params[:id])
+    authorize! :show, @project
+  end
+
+  def new
+    @project = Project.new
+    current_ability.attributes_for(:new, Project).each do |key, value|
+      @project.send("#{key}=", value)
+    end
+    @project.attributes = params[:project]
+    authorize! :new, @project
+  end
+
+  def create
+    @project = Project.new
+    current_ability.attributes_for(:create, Project).each do |key, value|
+      @project.send("#{key}=", value)
+    end
+    @project.attributes = params[:project]
+    authorize! :create, @project
+  end
+
+  def edit
+    @project = Project.find(params[:id])
+    authorize! :edit, @project
+  end
+
+  def update
+    @project = Project.find(params[:id])
+    authorize! :update, @project
+  end
+
+  def destroy
+    @project = Project.find(params[:id])
+    authorize! :destroy, @project
+  end
+
+  def some_other_action
+    if params[:id]
+      @project = Project.find(params[:id])
+    else
+      @projects = Project.accessible_by(current_ability)
+    end
+    authorize!(:some_other_action, @project || Project)
+  end
+end
+```
+
+The most complex behavior is inside the new and create actions. There it is setting some initial attribute values based on what the given user has permission to access. For example, if the user is only allowed to create projects where the "visible" attribute is true, then it would automatically set this upon building it.
+
+See [[Authorizing Controller Actions]] for details on what options you can pass to the `load_and_authorize_resource`.

--- a/docs/Custom-Actions.md
+++ b/docs/Custom-Actions.md
@@ -1,0 +1,27 @@
+When you define a user's abilities for a given model, you are not restricted to the 7 RESTful actions (create, update, destroy, etc.), you can create your own.
+
+For example, in [[Role Based Authorization]] I showed you how to define separate roles for a given user. However, you don't want all users to be able to assign roles, only admins. How do you set these fine-grained controls? Well you need to come up with a new action name. Let's call it `assign_roles`.
+
+```ruby
+# in models/ability.rb
+can :assign_roles, User if user.admin?
+```
+
+We can then check if the user has permission to assign roles when displaying the role checkboxes and assigning them.
+
+```rhtml
+<!-- users/_form.html.erb -->
+<% if can? :assign_roles, @user %>
+  <!-- role checkboxes go here -->
+<% end %>
+```
+
+```ruby
+# users_controller.rb
+def update
+  authorize! :assign_roles, @user if params[:user][:assign_roles]
+  # ...
+end
+```
+
+Now only admins will be able to assign roles to users.

--- a/docs/Debugging-Abilities.md
+++ b/docs/Debugging-Abilities.md
@@ -1,0 +1,61 @@
+What do you do when permissions you defined in the Ability class don't seem to be working properly? First try to duplicate this problem in the `rails console` or better yet, see [[Testing Abilities]].
+
+## Debugging Member Actions
+
+```ruby
+# in rails console or test
+user = User.first # fetch any user you want to test abilities on
+project = Project.first # any model you want to test against
+ability = Ability.new(user)
+ability.can?(:create, project) # see if it returns the expected behavior for that action
+```
+
+Note: this assumes that the model instance is being loaded properly. If you are only using `authorize_resource` it will not have an instance to work with so it will use the class.
+
+```ruby
+ability.can?(:create, Project)
+```
+
+## Debugging index Action
+
+```ruby
+# in rails console or test
+user = User.first # fetch any user you want to test abilities on
+ability = Ability.new(user)
+ability.can?(:index, Project) # see if user can access the class
+Project.accessible_by(ability) # see if returns the records the user can access
+Project.accessible_by(ability).to_sql # see what the generated SQL looks like to help determine why it's not fetching the records you want
+```
+
+If you find it is fetching the wrong records in complex cases, you may need to use an SQL condition instead of a hash inside the Ability class.
+
+```ruby
+can :update, Project, ["priority < ?", 3] do |project|
+  project.priority < 3
+end
+```
+
+See [[issue #213|https://github.com/ryanb/cancan/issues#issue/213]] for a more complex example.
+
+## Logging AccessDenied Exception
+
+If you think the `CanCan::AccessDenied` exception is being raised and you are not sure why, you can log this behavior to help debug what is triggering it.
+
+```ruby
+# in ApplicationController
+rescue_from CanCan::AccessDenied do |exception|
+  Rails.logger.debug "Access denied on #{exception.action} #{exception.subject.inspect}"
+  # ...
+end
+```
+
+## Issue Tracker
+
+If you are still unable to resolve the issue, please post on the [[issue tracker|https://github.com/ryanb/cancan/issues]]
+
+## Additional Docs
+
+* [[Defining Abilities]]
+* [[Checking Abilities]]
+* [[Ability Precedence]]
+* [[Testing Abilities]]

--- a/docs/Defining-Abilities-with-Blocks.md
+++ b/docs/Defining-Abilities-with-Blocks.md
@@ -1,0 +1,101 @@
+If your conditions are too complex to define in a hash (as shown in [[Defining Abilities]] page), you can use a block to define them in Ruby.
+
+```ruby
+can :update, Project do |project|
+  project.priority < 3
+end
+```
+
+If the block returns true then the user has that ability, otherwise he will be denied access.
+
+## Only for Object Attributes
+
+The block is **only** evaluated when an actual instance object is present. It is not evaluated when checking permissions on the class (such as in the `index` action). This means any conditions which are not dependent on the object attributes should be moved outside of the block.
+
+```ruby
+# don't do this
+can :update, Project do |project|
+  user.admin? # this won't be called for Project.accessible_by(current_ability, :update)
+end
+
+# do this
+can :update, Project if user.admin?
+```
+Note that if you pass a block to a `can` or `cannot`, regardless of whether the block asks for parameters (ex. `|project|`) the block only executes if an instance of a class is passed to `can?` or `cannot?`. 
+
+If you define a `can` or `cannot` with a block and an object is not passed, the check will pass. 
+```ruby
+can :update, Project do |project|
+  false
+end
+```
+```ruby
+can? :update, Project # returns true!
+```
+
+See [[Checking Abilities]] for more information.
+
+## Fetching Records
+
+A block's conditions are only executable through Ruby. If you are [[Fetching Records]] using `accessible_by` it will raise an exception. To fetch records from the database you need to supply an SQL string representing the condition. The SQL will go in the `WHERE` clause, if you need to do joins consider using sub-queries or scopes (below).
+
+```ruby
+can :update, Project, ["priority < ?", 3] do |project|
+  project.priority < 3
+end
+```
+
+If you are using `load_resource` and don't supply this SQL argument, the instance variable will not be set for the `index` action since they cannot be translated to a database query.
+
+
+## Block Conditions with Scopes
+
+It's also possible to pass a scope instead of an SQL string when using a block in an ability.
+
+```ruby
+can :read, Article, Article.published do |article|
+  article.published_at <= Time.now
+end
+```
+
+Generally, this breaks down to looks something like:
+
+```ruby
+can [:ability], Model, Model.scope_to_select_on_index_action do |model_instance|
+  model_instance.condition_to_evaluate_for_new_create_edit_update_destroy
+end
+```
+
+This is really useful if you have complex conditions which require `joins`. A couple of caveats:
+
+* You cannot use this with multiple `can` definitions that match the same action and model since it is not possible to combine them. An exception will be raised when that is the case.
+* If you use this with `cannot`, the scope needs to be the inverse since it's passed directly through. For example, if you don't want someone to read discontinued products the scope will need to fetch non discontinued ones:
+
+```ruby
+cannot :read, Product, Product.where(:discontinued => false) do |product|
+  product.discontinued?
+end
+```
+
+It is only recommended to use scopes if a situation is too complex for a hash condition.
+
+## Overriding All Behavior
+
+You can override all `can` behaviour by passing no arguments, this is useful when permissions are defined outside of ruby such as when defining [[Abilities in Database]].
+
+```ruby
+can do |action, subject_class, subject|
+  # ...
+end
+```
+
+Here the block will be triggered for every `can?` check, even when only a class is used in the check.
+
+
+## Additional Docs
+
+* [[Defining Abilities]]
+* [[Checking Abilities]]
+* [[Testing Abilities]]
+* [[Debugging Abilities]]
+* [[Ability Precedence]]

--- a/docs/Defining-Abilities-with-Hashes.md
+++ b/docs/Defining-Abilities-with-Hashes.md
@@ -1,0 +1,5 @@
+This section has been moved to [[Defining Abilities]] under "Hash of Conditions".
+
+## Checking with Class
+
+This section has been moved to [[Checking Abilities]].

--- a/docs/Defining-Abilities.md
+++ b/docs/Defining-Abilities.md
@@ -1,0 +1,171 @@
+The `Ability` class is where all user permissions are defined. An example class looks like this.
+
+```ruby
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :read, :all # permissions for every user, even if not logged in    
+    if user.present?  # additional permissions for logged in users (they can manage their posts)
+      can :manage, Post, user_id: user.id 
+      if user.admin?  # additional permissions for administrators
+        can :manage, :all
+      end
+    end
+  end
+end
+```
+
+The `current_user` model is passed into the initialize method, so the permissions can be modified based on any user attributes. CanCanCan makes no assumption about how roles are handled in your application. See [[Role Based Authorization]] for an example.
+
+## The `can` Method
+
+The `can` method is used to define permissions and requires two arguments. The first one is the action you're setting the permission for, the second one is the class of object you're setting it on.
+
+```ruby
+can :update, Article
+```
+
+You can pass `:manage` to represent any action and `:all` to represent any object.
+
+```ruby
+can :manage, Article  # user can perform any action on the article
+can :read, :all       # user can read any object
+can :manage, :all     # user can perform any action on any object
+```
+
+Common actions are `:read`, `:create`, `:update` and `:destroy` but it can be anything. See [[Action Aliases]] and [[Custom Actions]] for more information on actions.
+
+You can pass an array for either of these parameters to match any one. For example, here the user will have the ability to update or destroy both articles and comments.
+
+```ruby
+can [:update, :destroy], [Article, Comment]
+```
+
+
+**Important notice about :manage**. As you read above it represents ANY action on the object. So if you have something like:
+
+```ruby
+can :manage, User
+can :invite, User
+```
+
+you can get rid of the second line and the `:invite` permissions, because because `:manage` represents **any** action on object and `:manage` is not just `:create`, `:read`, `:update`, `:destroy` on object.
+
+If you want only CRUD actions on object, you should create custom action that called `:crud` for example, and use it instead of `:manage`:
+
+```ruby
+def initialize(user)
+  alias_action :create, :read, :update, :destroy, to: :crud
+  if user.present?
+    can :crud, User
+    can :invite, User
+  end
+end
+```
+
+## Hash of Conditions
+
+A hash of conditions can be passed to further restrict which records this permission applies to. Here the user will only have permission to read active projects which they own.
+
+```ruby
+can :read, Project, active: true, user_id: user.id
+```
+
+It is important to only use database columns for these conditions so it can be reused for [[Fetching Records]].
+
+You can use nested hashes to define conditions on associations. Here the project can only be read if the category it belongs to is visible.
+
+```ruby
+can :read, Project, category: { visible: true }
+```
+
+The above will issue a query that performs an `LEFT JOIN` to query conditions on associated records. 
+The example below will use a scope that returns all Photos that do not belong to a group.
+
+```ruby 
+class Photo
+  has_and_belongs_to_many :groups
+  scope :unowned, -> { left_joins(:groups).where(groups: { id: nil }) }
+end
+
+class Group
+  has_and_belongs_to_many :photos
+end
+
+class Ability
+  def initialize(user)    
+    can :read, Photo, Photo.unowned do |photo|
+      photo.groups.empty?
+    end
+  end
+end
+```
+
+An array or range can be passed to match multiple values. Here the user can only read projects of priority 1 through 3.
+
+```ruby
+can :read, Project, priority: 1..3
+```
+
+Almost anything that you can pass to a hash of conditions in Active Record will work here. The only exception is working with model ids. You can't pass in the model objects directly, you must pass in the ids.
+
+```ruby
+can :manage, Project, group: { id: user.group_ids }
+```
+
+If you have a complex case which cannot be done through a hash of conditions, see [[Defining Abilities with Blocks]].
+
+## Traverse associations
+
+All associations can be traversed when defining a rule.
+
+```ruby
+class User
+  belongs_to :account
+end
+
+class Account
+  has_one :user  
+  has_many :services
+end
+
+class Service
+  belongs_to :account
+  has_many :parts
+end
+
+class Part 
+  belongs_to :service
+end
+
+# Ability
+can :manage, Part, service: { account: { user: { id: user.id } } }
+```
+
+## Combining Abilities
+
+It is possible to define multiple abilities for the same resource. Here the user will be able to read projects which are released OR available for preview.
+
+```ruby
+can :read, Project, released: true
+can :read, Project, preview: true
+```
+
+The `cannot` method takes the same arguments as `can` and defines which actions the user is unable to perform. This is normally done after a more generic `can` call.
+
+```ruby
+can :manage, Project
+cannot :destroy, Project
+```
+
+The order of these calls is important. See [[Ability Precedence]] for more details.
+
+## Additional Docs
+
+* [[Defining Abilities: Best Practices]]
+* [[Defining Abilities with Blocks]]
+* [[Checking Abilities]]
+* [[Testing Abilities]]
+* [[Debugging Abilities]]
+* [[Ability Precedence]]

--- a/docs/Defining-Abilities:-Best-Practices.md
+++ b/docs/Defining-Abilities:-Best-Practices.md
@@ -1,0 +1,99 @@
+## Use hash conditions as much as possible
+
+Here's why:
+
+**1. Although scopes are fine for fetching, they pose a problem when authorizing a discrete action.**
+
+  For example, this declaration in Ability:
+
+  ```ruby
+  can :read, Article, Article.is_published
+  ```
+
+  causes this `CanCan::Error`:
+
+  ```
+  The can? and cannot? call cannot be used with a raw sql 'can' definition.
+  The checking code cannot be determined for :read #<Article ..>.
+  ```
+
+  A better way to define the same is:
+
+  ```ruby
+  can :read, Article, is_published: true
+  ```
+
+**2. Hash conditions are DRYer.**
+
+  By using hashes instead of blocks for all actions, you won't have to worry about translating blocks used for member controller actions (`:create`, `:destroy`, `:update`) to equivalent blocks for collection actions (`:index`, `:show`)—which require hashes anyway!
+
+**3. Hash conditions are OR'd in SQL, giving you maximum flexibilty.**
+  
+  Every time you define an ability with `can`, each `can` chains together with OR in the final SQL query for that model.
+
+  So if, in addition to the `is_published` condition above, we want to allow authors to see their drafts:
+
+  ```ruby
+    can :read, Article, author_id: @user.id, is_published: false
+  ```
+
+  Then the final SQL would be:
+
+  ```sql
+  SELECT `articles`.*
+  FROM   `articles`
+  WHERE  `articles`.`is_published` = 1
+  OR ( `articles`.`author_id` = 97 AND `articles`.`is_published` = 0 )
+  ```
+
+**4. For complex object graphs, hash conditions accommodate `joins` easily.**
+
+  See https://github.com/CanCanCommunity/cancancan/wiki/defining-abilities#hash-of-conditions.
+
+## Give permissions, don't take them away
+
+As I suggested in this [topic on Reddit](https://www.reddit.com/r/ruby/comments/6ytka8/refactoring_cancancan_abilities_brewing_bits/) you should, when possible, give increasing permissions to your users.
+CanCanCan increases permissions, it starts by giving no permissions to nobody and then increases those permissions depending on the user. A properly written ability.rb looks like that:
+
+```ruby
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :read, Post  # start by defining rules for all users, also not logged ones
+    return unless user.present?
+    can :manage, Post, user_id: user.id # if the user is logged in can manage it's own posts
+    can :create, Comment # logged in users can also create comments
+    return unless user.manager? # if the user is a manager we give additional permissions
+    can :manage, Comment # like managing all comments in the website
+    return unless user.admin?
+    can :manage, :all # finally we give all remaining permissions only to the admins
+  end
+end
+```
+
+following this good practice will help you to keep your permissions clean and more readable. 
+
+The risk of giving wrong permissions to the wrong users is also decreased.
+
+## Split your ability.rb file
+
+Another help, to make CanCanCan work more in a "pundit way" is to define a separate Ability file for each model, or controller, and then use
+
+```ruby
+def current_ability
+  @current_ability ||= MyAbility.new(current_user)
+end
+```
+
+To use a specific ability file: this way you don't have to load the whole ability.rb file on each request.
+
+Abilities files can always be merged together, so if you need two of them in one Controller, you can simply:
+
+```ruby
+def current_ability
+  @current_ability ||= ReadAbility.new(current_user).merge(WriteAbility.new(current_user))
+end
+```
+
+You can read more about splitting the Ability file in [this article](https://medium.com/@coorasse/cancancan-that-scales-d4e526fced3d)

--- a/docs/Devise.md
+++ b/docs/Devise.md
@@ -1,0 +1,22 @@
+You can bypass CanCanCan's authorization for Devise controllers:
+
+```ruby
+class ApplicationController < ActionController::Base
+  protect_from_forgery
+  check_authorization unless: :devise_controller?
+end
+```
+
+It may be a good idea to specify the rescue from action:
+
+```ruby
+rescue_from CanCan::Unauthorized do |exception|
+  if current_user.nil?
+    session[:next] = request.fullpath
+    redirect_to login_url, alert: 'You have to log in to continue.'
+  else
+    # render file: "#{Rails.root}/public/403.html", status: 403
+    redirect_back(fallback_location: root_path)
+  end
+end
+```

--- a/docs/Ensure-Authorization.md
+++ b/docs/Ensure-Authorization.md
@@ -1,0 +1,40 @@
+If you want to be certain authorization is not forgotten in some controller action, add `check_authorization` to your `ApplicationController`.
+
+```ruby
+class ApplicationController < ActionController::Base
+  check_authorization
+end
+```
+
+This will add an `after_filter` to ensure authorization takes place in every inherited controller action. If no authorization happens it will raise a `CanCan::AuthorizationNotPerformed` exception. You can skip this check by adding `skip_authorization_check` to that controller. Both of these methods take the same arguments as `before_filter` so you can exclude certain actions with `:only` and `:except`.
+
+```ruby
+class UsersController < ApplicationController
+  skip_authorization_check :only => [:new, :create]
+  # ...
+end
+```
+
+## Conditionally Check Authorization
+
+As of CanCan 1.6, the `check_authorization` method supports `:if` and `:unless` options. Either one takes a method name as a symbol. This method will be called to determine if the authorization check will be performed. This makes it very easy to skip this check on all Devise controllers since they provide a `devise_controller?` method.
+
+```ruby
+class ApplicationController < ActionController::Base
+  check_authorization :unless => :devise_controller?
+end
+```
+
+Here's another example where authorization is only ensured for the admin subdomain.
+
+```ruby
+class ApplicationController < ActionController::Base
+  check_authorization :if => :admin_subdomain?
+  private
+  def admin_subdomain?
+    request.subdomain == "admin"
+  end
+end
+```
+
+Note: The `check_authorization` only ensures that authorization is performed. If you have `authorize_resource` the authorization will still be performed no matter what is returned here.

--- a/docs/Exception-Handling.md
+++ b/docs/Exception-Handling.md
@@ -1,0 +1,115 @@
+The `CanCan::AccessDenied` exception is raised when calling `authorize!` in the controller and the user is not able to perform the given action. A message can optionally be provided.
+
+```ruby
+authorize! :read, Article, :message => "Unable to read this article."
+```
+
+This exception can also be raised manually if you want more custom behavior.
+
+```ruby
+raise CanCan::AccessDenied.new("Not authorized!", :read, Article)
+```
+
+The message can also be customized through internationalization.
+
+```yaml
+# in config/locales/en.yml
+en:
+  unauthorized:
+    manage:
+      all: "Not authorized to %{action} %{subject}."
+      user: "Not allowed to manage other user accounts."
+    update:
+      project: "Not allowed to update this project."
+```
+
+Notice `manage` and `all` can be used to generalize the subject and actions. Also `%{action}` and `%{subject}` can be used as variables in the message.
+
+You can catch the exception and modify its behavior in the `ApplicationController`. The behavior may vary depending on the request format. For example here we set the error message to a flash and redirect to the home page for HTML requests and return `403 Forbidden` for JSON requests.
+
+```ruby
+class ApplicationController < ActionController::Base
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.json { head :forbidden }
+      format.html { redirect_to main_app.root_url, :alert => exception.message }
+    end
+  end
+end
+```
+
+The action and subject can be retrieved through the exception to customize the behavior further.
+
+```ruby
+exception.action # => :read
+exception.subject # => Article
+```
+
+The default error message can also be customized through the exception. This will be used if no message was provided.
+
+```ruby
+exception.default_message = "Default error message"
+exception.message # => "Default error message"
+```
+
+If you prefer to return the 403 Forbidden HTTP code, create a `public/403.html` file and write a rescue_from statement like this example in `ApplicationController`:
+
+```ruby
+class ApplicationController < ActionController::Base
+  rescue_from CanCan::AccessDenied do |exception|
+    render :file => "#{Rails.root}/public/403.html", :status => 403, :layout => false
+    ## to avoid deprecation warnings with Rails 3.2.x (and incidentally using Ruby 1.9.3 hash syntax)
+    ## this render call should be:
+    # render file: "#{Rails.root}/public/403", formats: [:html], status: 403, layout: false
+  end
+end 
+```
+
+`403.html` must be pure HTML, CSS, and JavaScript--not a template. The fields of the exception are not available to it.
+
+If you are getting unexpected behavior when rescuing from the exception it is best to add some logging . See [[Debugging Abilities]] for details.
+
+## Rescuing exceptions for XML responses
+
+If your web application provides a web service which returns XML or JSON responses then you will likely want to handle Authorization properly with a 403 response. You can do so by rendering a response when rescuing from the exception.
+
+```ruby
+rescue_from CanCan::AccessDenied do |exception|
+  respond_to do |format|
+    format.json { render nothing: true, status: :forbidden }
+    format.xml { render xml: '...', status: :forbidden }
+    format.html { redirect_to main_app.root_url, alert: exception.message }
+  end
+end
+```
+
+## Danger of exposing sensible information
+
+Please read [this thread](https://github.com/CanCanCommunity/cancancan/issues/437) for more information.
+
+In a Rails application, if a record is not found during `load_and_authorize_resource` it raises `ActiveRecord::NotFound` before it checks _authentication_ in the `authorize` step.
+
+This means that secured routes can have their resources discovered without even being signed in:
+
+```
+$ curl -I https://app.example.com/restricted_resource/does-not-exist
+HTTP/1.1 404 Not Found
+
+$ curl -I https://app.example.com/restricted_resource/does-exist-but-not-permitted
+HTTP/1.1 302 Found
+Location: https://app.example.com/sessions/new
+```
+
+A more secure approach is to **always** return a 404 status instead of 302:
+
+```ruby
+class ApplicationController < ActionController::Base
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.json { render nothing: true, status: :not_found }
+      format.html { redirect_to main_app.root_url, notice: exception.message, status: :not_found }
+      format.js   { render nothing: true, status: :not_found }
+    end
+  end
+end
+```

--- a/docs/Fetching-Records.md
+++ b/docs/Fetching-Records.md
@@ -1,0 +1,47 @@
+Sometimes you need to restrict which records are returned from the database based on what the user is able to access. This can be done with the `accessible_by` method on any Active Record model. Simply pass the current ability to find only the records which the user is able to `:index`.
+
+```ruby
+# current_ability is a method made available by CanCanCan in your controllers
+@articles = Article.accessible_by(current_ability)
+```
+
+You can change the action by passing it as the second argument. Here we find only the records the user has permission to update.
+
+```ruby
+@articles = Article.accessible_by(current_ability, :update) 
+```
+
+If you want to use the current controller's action, make sure to call `to_sym` on it:
+
+```ruby
+@articles = Article.accessible_by(current_ability, params[:action].to_sym)
+```
+
+This is an Active Record scope so other scopes and pagination can be chained onto it.
+
+This works with multiple `can` definitions, which allows you to define complex permission logic and have it translated properly to SQL.
+
+Given the definition:
+```ruby
+class Ability
+  can :manage, User, manager_id: user.id
+  cannot :manage, User, self_managed: true
+  can :manage, User, id: user.id
+end
+```
+a call to User.accessible_by(current_ability) generates the following SQL
+
+```sql
+SELECT *
+FROM users
+WHERE (id = 1) OR (not (self_managed = 't') AND (manager_id = 1))
+```
+
+It will raise an exception if any requested model's ability definition is defined using just block. 
+You can define SQL fragment in addition to block (look for more examples in [[Defining Abilities with Blocks]]).
+
+If you are using something other than Active Record you can fetch the conditions hash directly from the current ability.
+
+```ruby
+current_ability.model_adapter(TargetClass, :read).conditions
+```

--- a/docs/FriendlyId-support.md
+++ b/docs/FriendlyId-support.md
@@ -1,0 +1,30 @@
+If you are using FriendlyId you will probably like something to make cancan compatible with it.
+
+You do not have to write `find_by :slug` or something like that, that is always error prone.
+
+You just need to create a `config/initizializers/cancan.rb` file with:
+```ruby
+if defined?(CanCan)
+  class Object
+    def metaclass
+      class << self; self; end
+    end
+  end
+
+  module CanCan
+    module ModelAdapters
+      class ActiveRecord4Adapter < AbstractAdapter
+        @@friendly_support = {}
+
+        def self.find(model_class, id)
+          klass =
+          model_class.metaclass.ancestors.include?(ActiveRecord::Associations::CollectionProxy) ?
+            model_class.klass : model_class
+          @@friendly_support[klass]||=klass.metaclass.ancestors.include?(FriendlyId)
+          @@friendly_support[klass] == true ? model_class.friendly.find(id) : model_class.find(id)
+        end
+      end
+    end
+  end
+end
+```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,43 @@
+### Getting Started
+
+* [[README|https://github.com/CanCanCommunity/cancancan#readme]]
+* [[Defining Abilities]], [Best Practices](https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities%3A-Best-Practices)
+* [[Checking Abilities]]
+* [[Authorizing Controller Actions]]
+* [[Exception Handling]]
+* [[Ensure Authorization]]
+* [[Changing Defaults]]
+* [[Translations (i18n)]]
+
+### More about Abilities
+
+* [[Testing Abilities]]
+* [[Debugging Abilities]]
+* [[Ability Precedence]]
+* [[Fetching Records]]
+* [[Action Aliases]]
+* [[Custom Actions]]
+* [[Role Based Authorization]]
+
+
+### More about Controllers & Views
+
+* [[Controller Authorization Example]]
+* [[Nested Resources]]
+* [[Strong Parameters]]
+* [[Non RESTful Controllers]]
+* [[Link Helpers]]
+
+
+### Other Use Cases
+
+* [[Inherited Resources]]
+* [[Mongoid]]
+* [[Rails Admin|https://github.com/sferik/rails_admin/wiki/CanCanCan]]
+* [[Devise]]
+* [[Accessing Request Data]]
+* [[Abilities in Database]]
+* [[Ability for Other Users]]
+* [[Other Authorization Solutions]]
+
+**Can't find what you're looking for? [Submit a Question on StackOverflow](http://stackoverflow.com/questions/ask?tags=cancancan)

--- a/docs/Inherited-Resources.md
+++ b/docs/Inherited-Resources.md
@@ -1,0 +1,42 @@
+**This guide is for cancancan < 2.0 only.
+If you want to use Inherited Resources and cancancan 2.0 please check for extensions like https://github.com/TylerRick/cancan-inherited_resources**
+
+The `load_and_authorize_resource` call will automatically detect if you are using [[Inherited Resources|http://github.com/josevalim/inherited_resources]] and load the resource through that. The `load` part in CanCan is still necessary since Inherited Resources does lazy loading. This will also ensure the behavior is identical to normal loading.
+
+```ruby
+class ProjectsController < InheritedResources::Base
+  load_and_authorize_resource
+end
+```
+
+if you are doing nesting you will need to mention it in both Inherited Resources and CanCan.
+
+```ruby
+class TasksController < InheritedResources::Base
+  belongs_to :project
+  load_and_authorize_resource :project
+  load_and_authorize_resource :task, :through => :project
+end
+```
+<i>Please note that even for a `has_many :tasks` association, the `load_and_authorize_resource` needs the singular name of the associated model...</i>
+
+**Warning**: when overwriting the `collection` method in a controller the `load` part of a `load_and_authorize_resource` call will not work correctly. See https://github.com/ryanb/cancan/issues/274 for the discussions. 
+
+In this case you can override collection like
+```ruby
+skip_load_and_authorize_resource :only => :index
+
+def collection
+  @products ||= end_of_association_chain.accessible_by(current_ability).paginate(:page => params[:page], :per_page => 10)
+end
+```
+
+## Mongoid
+With mongoid it is necessary to reference `:project_id` instead of just `:project`
+
+```ruby
+class TasksController < InheritedResources::Base
+  ...
+  load_and_authorize_resource :task, :through => :project_id
+end
+```

--- a/docs/Issue-Collaborators.md
+++ b/docs/Issue-Collaborators.md
@@ -1,0 +1,27 @@
+The CanCan issue tracker has gotten out of hand because I have not had time to work on it recently. I am bringing on several Issue Collaborators to help. My goal is to make CanCan the best it can be and getting the issue tracker under control will help give me a clear direction on where to take it in 2.0.
+
+**Note: even though issue collaborators have full commit access, please do not make any commits or merge in any pull requests.** I am just looking for help cleaning up the issue tracker at the moment. I will likely take on full collaborators in the future.
+
+### Guidelines
+
+* **Questions:** If someone has a question that can be solved with the [wiki docs](https://github.com/ryanb/cancan/wiki) please point them to the appropriate docs and close the issue. If the question is not clearly answered by the wiki please improve the wiki so that it is and close the issue. If you do not have time to add docs at the moment, tag it with `docs` and `help` labels and keep it open.
+
+* **Feature Requests:** If it is a feature request that could go in CanCan 2.0, please tag it with `2.0` and `feature` tags. If you are uncertain whether it's a good idea, add a `discuss` tag to get some feedback. I don't plan to add features to CanCan 1 at this point, if it only applies to that release please close it and add a comment saying so.
+
+* **Dormant Issues:** If you are uncertain if an issue is still applicable and do not want to spend time investigating it, just ask "Are you still having this problem?" and tag with `waiting`. If you do not get a response within a week or so, close the issue. Mention you can open the issue again if they respond.
+
+* **Duplicate Issues:** If it seems like a common issue, do a search and look for a duplicate. If it is, close the issue and link to the other original one.
+
+* **Bug Reports:** If CanCan is not behaving in a way that it is documented to, add the `bug` label. Please verify this bug by trying it on your own and add a `verified` label to it if you can duplicate the problem.
+
+  If you would like to submit a pull request to fix this bug, assign the issue to yourself so others know you are working on it. If not, add a comment saying you are looking for someone to write a pull request and add a `help` label to it. When a pull request is available, close the original issue and link to it from the pull request.
+
+* **Pull Requests:** Please try pull requests on your local machine to see if the tests pass and the functionality works as described. If so, add a `verified` label. Also add a `bug` or `feature` label depending on the type of request. If it is urgent, add a `critical` tag and ping me at @rbates on Twitter and I'll try to get it pulled in quickly.
+
+  I will be reluctant to merge pull requests that are large or have features I feel unnecessary. Please add a comment to pull requests explaining your thinking on if it should be merged in and if you can think of a better way to do it.
+
+It is a good idea to occasionally check the `help` and `discuss` tags to give your input on other issues.
+
+**Final note:** if you are ever uncertain about whether to close an issue or leave it open. Close it and add a note saying you will open it again if someone comments. If it is beyond your expertise, just tag it with `help` and move on.
+
+Thank you very much for your help in cleaning up the issue tracker. If you have any questions, send me an email and I'll update this.

--- a/docs/Link-Helpers.md
+++ b/docs/Link-Helpers.md
@@ -1,0 +1,39 @@
+Generally you only want to show new/edit/destroy links when the user has permission to perform that action. You can do so like this in the view.
+
+```rhtml
+<% if can? :update, @project %>
+  <%= link_to "Edit", edit_project_path(@project) %>
+<% end %>
+```
+
+However if you find yourself repeating this pattern often you may want to add helper methods like this.
+
+```ruby
+# in ApplicationHelper
+def show_link(object, content = "Show")
+  link_to(content, object) if can?(:read, object)
+end
+
+def edit_link(object, content = "Edit")
+  link_to(content, [:edit, object]) if can?(:update, object)
+end
+
+def destroy_link(object, content = "Destroy")
+  link_to(content, object, :method => :delete, :confirm => "Are you sure?") if can?(:destroy, object)
+end
+
+def create_link(object, content = "New")
+  if can?(:create, object)
+    object_class = (object.kind_of?(Class) ? object : object.class)
+    link_to(content, [:new, object_class.name.underscore.to_sym])
+  end
+end
+```
+
+Then a link is as simple as this.
+
+```rhtml
+<%= edit_link @project %>
+```
+
+I only recommend doing this if you see this pattern a lot in your application. There are times when the view code is more complex where this doesn't fit well.

--- a/docs/MetaWhere.md
+++ b/docs/MetaWhere.md
@@ -1,0 +1,1 @@
+MetaWhere is not supported anymore

--- a/docs/Migrating-from-CanCanCan-2.x-to-3.0.md
+++ b/docs/Migrating-from-CanCanCan-2.x-to-3.0.md
@@ -1,0 +1,15 @@
+### Breaking changes
+
+* **Defining abilities without a subject is not allowed anymore.**
+For example, `can :dashboard` is not going to be accepted anymore and will raise an exception.
+All these kind of rules need to be rethought in terms of `can action, subject`. `can :read, :dashboard` for example.
+
+* **Eager loading is not automatic.** If you relied on CanCanCan to avoid N+1 queries, this will not be the case anymore.
+From now on, all necessary `includes`, `preload` or `eager_load` need to be explicitly written. We strongly suggest to have
+`bullet` gem installed to identify your possible N+1 issues.
+
+* **Use of distinct.** Uniqueness of the results is guaranteed by using the `distinct` clause in the final query.
+This may cause issues with some existing queries when using clauses like `group by` or `order` on associations.
+Adding a custom `select` may be necessary in these cases.
+
+* **aliases are now merged.** When using the method to merge different Ability files, the aliases are now also merged. This might cause some incompatibility issues.

--- a/docs/Model-Adapter.md
+++ b/docs/Model-Adapter.md
@@ -1,0 +1,130 @@
+CanCan includes a model adapter layer which allows it to change behavior depending on the model used. The current adapters are.
+
+* ActiveRecord
+* [[Mongoid]]
+
+See [[spec/README|https://github.com/CanCanCommunity/cancancan/blob/master/spec/README.rdoc]] for how to run specs for a given adapter.
+
+## Creating a Model Adapter
+
+It is easy to make your own adapter if one is not provided. Here I'll walk you through the steps to recreate the Mongoid adapter.
+
+### The Specs
+
+First, fork the CanCan GitHub project and clone that repo. Next, add the necessary gems to the Gemfile for working with the adapter in the specs.
+
+```ruby
+case ENV["MODEL_ADAPTER"]
+# ...
+when "mongoid"
+  gem "bson_ext", "~> 1.1"
+  gem "mongoid", "~> 2.0.0.beta.20"
+# ...
+end
+```
+
+Next create a spec for the adapter which tests basic behavior. For example, here's a simple Mongoid spec that would go under `spec/cancan/model_adapters/mongoid_adapter_spec.rb`
+
+```ruby
+if ENV["MODEL_ADAPTER"] == "mongoid"
+  require "spec_helper"
+
+  class MongoidProject
+    include Mongoid::Document
+  end
+
+  Mongoid.configure do |config|
+    config.master = Mongo::Connection.new('127.0.0.1', 27017).db("cancan_mongoid_spec")
+  end
+
+  describe CanCan::ModelAdapters::MongoidAdapter do
+    context "Mongoid defined" do
+      before(:each) do
+        @ability = Object.new
+        @ability.extend(CanCan::Ability)
+      end
+
+      it "should return the correct records based on the defined ability" do
+        @ability.can :read, MongoidProject, :title => "Sir"
+        sir   = MongoidProject.create(:title => 'Sir')
+        lord  = MongoidProject.create(:title => 'Lord')
+        MongoidProject.accessible_by(@ability, :read).entries.should == [sir]
+      end
+    end
+  end
+end
+```
+
+You will need many more specs for full coverage but add them one at a time. To run the specs execute the following commands.
+
+```bash
+MODEL_ADAPTER=mongoid bundle
+MODEL_ADAPTER=mongoid rake
+```
+
+That will fail since we have not added the implementation.
+
+### The Implementation
+
+First add a line to `lib/cancan.rb` for including the adapter only when Mongoid is present.
+
+```ruby
+require 'cancan/model_adapters/mongoid_adapter' if defined? Mongoid
+```
+
+Next create that adapter under `lib/cancan/model_adapters/mongoid_adapter.rb`.
+
+```ruby
+module CanCan
+  module ModelAdapters
+    class MongoidAdapter < AbstractAdapter
+      def self.for_class?(model_class)
+        model_class <= Mongoid::Document
+      end
+
+      def database_records
+        if @rules.size == 0  
+          @model_class.where(:_id => {'$exists' => false, '$type' => 7}) # return no records in Mongoid
+        else
+          @rules.inject(@model_class.all) do |records, rule|
+            if rule.base_behavior
+              records.or(rule.conditions)
+            else
+              records.excludes(rule.conditions)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+module Mongoid::Document::ClassMethods
+  include CanCan::ModelAdditions::ClassMethods
+end
+```
+
+The class method called `for_class?` is used to determine if this adapter should be used for a given class. Here we just see if that model is a Mongoid document.
+
+The `database_records` method is used in the `accessible_by` call. Here we fetch records from `@model_class` which match the `@rules`. If there are no rules then we return a query which fetches no records.
+
+Otherwise we start with all the records and apply each of the rule conditions to them. The `rule.base_behavior` defines whether this rule should be additive or subtractive. It is `true` for a `can` call and `false` for a `cannot` call.
+
+The last three lines add the `accessible_by` method to all Mongoid classes. I expect this to not be necessary in CanCan 2.0 (see [[issue #235|https://github.com/ryanb/cancan/issues#issue/235]]).
+
+Some models add additional features to the conditions hash. With Mongoid you can do something like `:age.gt => 13`. To get this working a couple more methods need to be added to the adapter to override how conditions are checked.
+
+```ruby
+# in MongoidAdapter
+def self.override_conditions_hash_matching?(subject, conditions)
+  conditions.any? { |k,v| !k.kind_of?(Symbol) }
+end
+
+def self.matches_conditions_hash?(subject, conditions)
+  subject.matches? subject.class.where(conditions).selector
+end
+```
+
+The first one returns `true` when there's a conditions option which is not a Symbol (such as `:age.gt`). The second method will be called by CanCan when the first one returns true to check if the given subject matches the hash of conditions.
+
+See the actual [[mongoid_adapter_spec.rb|https://github.com/ryanb/cancan/blob/master/spec/cancan/model_adapters/mongoid_adapter_spec.rb]] and [[mongoid_adapter.rb|https://github.com/ryanb/cancan/blob/master/lib/cancan/model_adapters/mongoid_adapter.rb]] files for the full code.

--- a/docs/Mongoid.md
+++ b/docs/Mongoid.md
@@ -1,0 +1,17 @@
+** **Attention: Supported only on cancancan < 2.0!** **
+
+CanCanCan supports [[Mongoid|http://mongoid.org]]. All you have to do is mention `mongoid` before `cancan` in your Gemfile so it is required first.
+
+```ruby
+gem "mongoid"
+gem "cancan"
+```
+
+That is it, you can now call `accessible_by` on any Mongoid document (which is done automatically in the `index` action). You can also use the query syntax that Mongoid provides when defining the abilities.
+
+```ruby
+# in Ability
+can :read, Article, :priority.lt => 5
+```
+
+This is all done through a [[Model Adapter]]. See that page for more information and how you can add your own.

--- a/docs/Multiple-can-definitions.textile
+++ b/docs/Multiple-can-definitions.textile
@@ -1,0 +1,35 @@
+h2. Multiple `can` definitions
+
+It is possible to specify multiple `can` and `cannot` definitions with hashes and have it properly translate to a single SQL query.
+
+```ruby
+# in ability.rb
+can :manage, User, id: 1
+can :manage, User, manager_id: 1
+cannot :manage, User, self_managed: true
+```
+
+When using `accessible_by` it will translate to SQL conditions that look like this.
+
+```sql
+not (self_managed = 't') AND ((manager_id = 1) OR (id = 1))
+```
+
+If you have the following definition:
+
+```ruby
+can :manage, User, id: user.id
+can :assign_roles, User do
+  user.admin?
+end
+```
+
+and you call `can? :assign_roles, some_user` it evaluates to `true` when `current_user == some_user` because it falls back to `can :manage, User, id: user.id`.
+
+Proper can definition should be now:
+
+```ruby
+can :manage, User, id: user.id
+cannot :assign_roles, User
+can :assign_roles, User if user.admin?
+```

--- a/docs/Nested-Resources.md
+++ b/docs/Nested-Resources.md
@@ -1,0 +1,160 @@
+Let's say we have nested resources set up in our routes.
+
+```ruby
+resources :projects do
+  resources :tasks
+end
+```
+
+We can then tell CanCanCan to load the project and then load the task through that.
+
+```ruby
+class TasksController < ApplicationController
+  load_and_authorize_resource :project
+  load_and_authorize_resource :task, through: :project
+end
+```
+
+This will fetch the project using `Project.find(params[:project_id])` on every controller action, save it in the `@project` instance variable, and authorize it using the `:read` action to ensure the user has the ability to access that project. If you don't want to do the authorization you can simply use `load_resource`, but calling just `authorize_resource` for the parent object is insufficient. The task is then loaded through the `@project.tasks` association.
+
+If the name of the association doesn't match the resource name, for instance `has_many :issues, class_name: 'Task'`, you can specify the association name using `:through_association`.
+
+```ruby
+  class TasksController < ApplicationController
+    load_and_authorize_resource :project
+    load_and_authorize_resource :task, through: :project, through_association: :issues
+  end
+```
+
+If the resource name (`:project` in this case) does not match the controller then it will be considered a parent resource. You can manually specify parent/child resources using the `parent: false` option.
+
+
+## Nested through method
+
+It's also possible to nest through a method, this is commonly the `current_user` method.
+
+```ruby
+class ProjectsController < ApplicationController
+  load_and_authorize_resource through: :current_user
+end
+```
+
+Here everything will be loaded through the `current_user.projects` association.
+
+## Shallow nesting
+
+The parent resource is required to be present and it will raise an exception if the parent is ever `nil`. 
+If you want it to be optional (such as with shallow routes), add the `shallow: true` option to the child.
+
+```ruby
+class TasksController < ApplicationController
+  load_and_authorize_resource :project
+  load_and_authorize_resource :task, through: :project, shallow: true
+end
+```
+
+## Singleton resource
+
+What if each project only had one task through a `has_one` association? To set up singleton resources you can use the `:singleton` option.
+
+```ruby
+class TasksController < ApplicationController
+  load_and_authorize_resource :project
+  load_and_authorize_resource :task, through: :project, singleton: true
+end
+```
+
+It will then use the `@project.task` and `@project.build_task` methods for fetching and building respectively.
+
+## Polymorphic associations
+
+Let's say tasks can either be assigned to a Project or an Event through a polymorphic association. An array can be passed into the `:through` option and it will use the first one it finds.
+
+```ruby
+load_resource :project
+load_resource :event
+load_and_authorize_resource :task, through: [:project, :event]
+```
+
+Here it will check both the `@project` and `@event` variables and fetch the task through whichever one exists. Note that this is only loading the parent model, if you want to authorize the parent you will need to do it through a before_filter because there is special logic involved.
+
+```ruby
+before_filter :authorize_parent
+
+private
+
+def authorize_parent
+  authorize! :read, (@event || @project)
+end
+```
+
+## Accessing parent in ability
+
+Sometimes the child permissions are closely tied to the parent resource. For example, if there is a `user_id` column on Project, one may want to only allow access to tasks if the user owns their project.
+
+This will happen automatically due to the `@project` instance being authorized in the nesting. However it's still a good idea to restrict the tasks separately. You can do so by going through the project association.
+
+```ruby
+# in Ability
+can :manage, Task, project: { user_id: user.id }
+```
+
+This means you will need to have a project tied to the tasks which you pass into here. For example, if you are checking if the user has permission to create a new task, do that by building it through the project.
+
+```ruby
+can? :create, @project.tasks.build
+```
+
+It's also possible to check permission through an association like this.
+
+```ruby
+can? :read, @project => Task
+```
+
+This will use the above `:project` hash conditions and ensure `@project` meets those conditions.
+
+## Has_many through associations
+How to load and authorize resources with a has_many :through association?
+
+Given that situation:
+
+```ruby
+class User < ActiveRecord::Base
+  has_many :groups_users
+  has_many :groups, through: :groups_users
+end
+```
+
+```ruby
+class Group < ActiveRecord::Base
+  has_many :groups_users
+  has_many :users, through: :groups_users
+end
+```
+
+```ruby
+class GroupsUsers < ActiveRecord::Base
+  belongs_to :group, inverse_of: :groups_users
+  belongs_to :user, inverse_of: :groups_users
+end
+```
+
+and in the controller:
+
+```ruby
+class UsersController < ApplicationController
+  load_and_authorize_resource :group
+  load_and_authorize_resource through: :group
+```
+
+in ability.rb
+
+```ruby
+can :create, User, groups_users: {group: {CONDITION_ON_GROUP} }
+```
+
+Don't forget the **inverse_of** option, is the trick to make it works correctly. 
+
+Remember to define the ability through the **groups_users** model (i.e. don't write `can :create, User, groups: {CONDITION_ON_GROUP}`)
+
+You will be able to persist the association just calling `@user.save` instead of `@group.save`

--- a/docs/Non-RESTful-Controllers.md
+++ b/docs/Non-RESTful-Controllers.md
@@ -1,0 +1,35 @@
+You can use CanCan with controllers that do not follow the traditional show/new/edit/destroy actions, however you should not use the `load_and_authorize_resource` method since there is no resource to load. Instead you can call `authorize!` in each action separately.
+
+**NOTE:** This is **not** the same as having additional non-RESTful actions on a RESTful controller. See the Choosing Actions section of the [[Authorizing Controller Actions]] page for details.
+
+For example, let's say we have a controller which does some miscellaneous administration tasks such as rolling log files. We can use the `authorize!` method here.
+
+```ruby
+class AdminController < ActionController::Base
+  def roll_logs
+    authorize! :roll, :logs
+    # roll the logs here
+  end
+end
+```
+
+And then authorize that in the `Ability` class.
+
+```ruby
+can :roll, :logs if user.admin?
+```
+
+Notice you can pass a symbol as the second argument to both `authorize!` and `can`. It doesn't have to be a model class or instance. Generally the first argument is the "action" one is trying to perform and the second argument is the "subject" the action is being performed on. It can be anything.
+
+## Alternative: authorize_resource
+
+Alternatively you can use the `authorize_resource` and specify that there's no class. This way it will pass the resource symbol instead. This is good if you still have a Resource-like controller but no model class backing it.
+
+```ruby
+class ToolsController < ApplicationController
+  authorize_resource :class => false
+  def show
+    # automatically calls authorize!(:show, :tool)
+  end
+end
+```

--- a/docs/Other-Authorization-Solutions.md
+++ b/docs/Other-Authorization-Solutions.md
@@ -1,0 +1,7 @@
+There are many authorization solutions available, and it is important to find one which best meets the application requirements. 
+
+We try to keep CanCanCan minimal yet extendable so it can be used in many situations, but there are times it doesn't fit the best.
+
+If you find the conditions hash to be too limiting I encourage you to check out [[Pundit|https://github.com/elabs/pundit]] which offers a sophisticated DSL for handling more complex permission scenarios. This allows one to generate complex database queries based on the permissions but at the cost of a more complex DSL.
+
+Also consider, if you have very unique authorization requirements, the best choice may be to write your own solution instead of trying to shoe-horn an existing plugin.

--- a/docs/Role-Based-Authorization.md
+++ b/docs/Role-Based-Authorization.md
@@ -1,0 +1,175 @@
+CanCanCan is decoupled from how you implement roles in the User model, but how might one set up basic role-based authorization? The pros and cons are described [here](https://github.com/kristianmandrup/cantango/wiki/CanCan-vs-CanTango).
+
+The following approach allows you to simply define the role abilities in Ruby and does not need a role model. Alternatively, [[Separate Role Model]] describes how to define the roles and mappings in a database.
+
+Since there is such a tight coupling between the list of roles and abilities, I recommend keeping the list of roles in Ruby. You can do so in a constant under the User class.
+
+```ruby
+class User < ActiveRecord::Base
+  ROLES = %i[admin moderator author banned]
+end
+```
+
+But now, how do you set up the association between the user and the roles? You'll need to decide if the user can have many roles or just one.
+
+## One role per user
+
+If a user can have only one role, it's as simple as adding a `role` string column to the `users` table.
+
+```bash
+rails generate migration add_role_to_users role:string
+rake db:migrate
+```
+
+In your `users_controller.rb` add `:role` to the list of permitted parameters  
+
+```ruby
+def user_params
+  params.require(:user).permit(:name, :email, :password, :password_confirmation, :role)
+end
+```
+If you're using ActiveAdmin don't forget to add `role` to the `user.rb` list of parameters as well
+
+```ruby
+  permit_params :name, :email, :role
+```
+
+Now you can provide a select-menu for choosing the roles in the view.
+
+```rhtml
+<!-- in users/_form.html.erb -->
+<%= f.collection_select(:role, User::ROLES, :to_s, lambda{|i| i.to_s.humanize}) %>
+```
+
+You may not have considered using `collection_select` when you aren't working with an association, but it will work perfectly. In this case the user will see the humanized name of the role, and the simple lower-cased version will be passed in as the value when the form is submitted.
+
+It's then very simple to determine the role of the user in the Ability class.
+
+```ruby
+can :manage, :all if user.role == "admin"
+```
+
+
+## Many roles per user
+
+It is possible to assign multiple roles to a user and store it into a single integer column using a [[bitmask|http://en.wikipedia.org/wiki/Mask_(computing)]]. First add a `roles_mask` integer column to your `users` table.
+
+```bash
+rails generate migration add_roles_mask_to_users roles_mask:integer
+rake db:migrate
+```
+
+Next you'll need to add the following code to the User model for getting and setting the list of roles a user belongs to. This will perform the necessary bitwise operations to translate an array of roles into the integer field.
+
+```ruby
+# in models/user.rb
+def roles=(roles)
+  roles = [*roles].map { |r| r.to_sym }
+  self.roles_mask = (roles & ROLES).map { |r| 2**ROLES.index(r) }.inject(0, :+)
+end
+
+def roles
+  ROLES.reject do |r|
+    ((roles_mask.to_i || 0) & 2**ROLES.index(r)).zero?
+  end
+end
+```
+
+If you're using devise, don't forget to add `attr_accessible :roles` to your user model or add following to application_controller.rb
+
+```ruby
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  protected
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.for(:sign_up)  { |u| u.permit(  :email, :password, :password_confirmation, roles: [] ) }
+  end
+```
+You can use checkboxes in the view for setting these roles.
+
+```rhtml
+<% for role in User::ROLES %>
+  <%= check_box_tag "user[roles][#{role}]", role, @user.roles.include?(role), {:name => "user[roles][]"}%>
+  <%= label_tag "user_roles_#{role}", role.to_s.humanize %><br />
+<% end %>
+<%= hidden_field_tag "user[roles][]", "" %>
+```
+
+Finally, you can then add a convenient way to check the user's roles in the Ability class.
+
+```ruby
+# in models/user.rb
+def has_role?(role)
+  roles.include?(role)
+end
+
+# in models/ability.rb
+can :manage, :all if user.has_role? :admin
+```
+
+See [[Custom Actions]] for a way to restrict which users can assign roles to other users.
+
+This functionality has also been extracted into a little gem called [[role_model|http://rubygems.org/gems/role_model]] ([[code & howto|http://github.com/martinrehfeld/role_model]]).
+
+If you do not like this bitmask solution, see [[Separate Role Model]] for an alternative way to handle this.
+
+
+## Role Inheritance
+
+Sometimes you want one role to inherit the behavior of another role. For example, let's say there are three roles: moderator, admin, superadmin and you want each one to inherit the abilities of the one before. There is also a "role" string column in the User model. You should create a method in the User model which has the inheritance logic.
+
+```ruby
+# in User
+ROLES = %w[moderator admin superadmin]
+def role?(base_role)
+  ROLES.index(base_role.to_s) <= ROLES.index(role)
+end
+```
+
+You then use this in the Ability class.
+
+```ruby
+# in Ability#initialize
+if user.role? :moderator
+  can :manage, Post
+end
+if user.role? :admin
+  can :manage, ForumThread
+end
+if user.role? :superadmin
+  can :manage, Forum
+end
+```
+
+Here a superadmin will be able to manage all three classes but a moderator can only manage the one. Of course you can change the role logic to fit your needs. You can add complex logic so certain roles only inherit from others. And if a given user can have multiple roles you can decide whether the lowest role takes priority or the highest one does. Or use other attributes on the user model such as a "banned", "activated", or "admin" column.
+
+This functionality has been extracted into a gem called [[canard|http://rubygems.org/gems/canard]] ([[code & howto|http://github.com/james2m/canard]]).
+
+## Alternative Role Inheritance
+
+If you would like to keep the inheritance rules in the Ability class instead of the User model it is easy to do so like this.
+
+```ruby
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    @user = user || User.new # for guest
+    @user.roles.each { |role| send(role.name_to_symbol) }
+
+    if @user.roles.size == 0
+      can :read, :all #for guest without roles
+    end
+  end
+
+  def manager
+    can :manage, Employee
+  end
+
+  def admin
+    manager
+    can :manage, Bill
+  end
+end
+```
+
+Here each role is a separate method which is called. You can call one role inside another to define inheritance. This assumes you have a `User#roles` method which returns an array of all roles for that user.

--- a/docs/Rules-compression.md
+++ b/docs/Rules-compression.md
@@ -1,0 +1,44 @@
+# Rules compressions
+
+Your rules are optimized automatically at runtime. There are a set of "rules" to optimize your rules definition and they are implemented in the `RulesCompressor` class. Here you can see how this works:
+
+A rule without conditions is defined as `catch_all`.
+
+
+### A catch_all rule, eliminates all previous rules and all subsequent rules of the same type
+
+```ruby
+can :read, Book, author_id: user.id
+cannot :read, Book, private: true
+can :read, Book
+can :read, Book, id: 1
+cannot :read, Book, private: true
+```
+becomes
+```ruby
+can :read, Book
+cannot :read, Book, private: true
+```
+
+### If a catch_all cannot rule is first, it can be removed
+
+```ruby
+cannot :read, Book
+can :read, Book, author_id: user.id
+```
+becomes
+```ruby
+can :read, Book, author_id: user.id
+```
+
+### If all rules are cannot rules, this is equivalent to no rules
+
+```ruby
+cannot :read, Book, private: true
+```
+becomes
+```ruby
+# nothing
+```
+
+These optimizations allow you to follow the strategy of ["Give Permissions, don't take them"](https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities%3A-Best-Practices#give-permissions-dont-take-them-away) and automatically ignore previous rules when they are not needed.

--- a/docs/Separate-Role-Model.md
+++ b/docs/Separate-Role-Model.md
@@ -1,0 +1,87 @@
+This approach uses a separate role and shows how to setup a many-to-many association, Assignment, between User and Role. Alternatively, [[Role Based Authorization]] describes a simple ruby based approach that defines the roles within ruby.
+
+```ruby
+class User < ActiveRecord::Base
+  has_many :assignments
+  has_many :roles, :through => :assignments
+end
+
+class Assignment < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :role
+end
+
+class Role < ActiveRecord::Base
+  has_many :assignments
+  has_many :users, :through => :assignments
+end
+```
+
+You can assign roles using checkboxes when creating or updating a user model.
+
+```rhtml
+<% for role in Role.all %>
+<div>
+  <%= check_box_tag "user[role_ids][]", role.id, @user.roles.include?(role) %>
+  <%=h role.name %>
+</div>
+<% end %>
+<%= hidden_field_tag "user[role_ids][]", "" %>
+```
+
+Or you may want to [[use Formtastic|http://railscasts.com/episodes/185-formtastic-part-2]] for this.
+
+Next you need to determine if a user is in a specific role. You can create a method in the User model for this.
+
+```ruby
+# in models/user.rb
+def has_role?(role_sym)
+  roles.any? { |r| r.name.underscore.to_sym == role_sym }
+end
+```
+
+And then you can use this in your Ability.
+
+```ruby
+# in models/ability.rb
+def initialize(user)
+  user ||= User.new # in case of guest
+  if user.has_role? :admin
+    can :manage, :all
+  else
+    can :read, :all
+  end
+end
+```
+
+That's it!
+
+## Role Inheritance Within Ability.rb
+
+You can use the Alternative Role Inheritance strategy described in [[Role Based Authorization|https://github.com/ryanb/cancan/wiki/Role-Based-Authorization]] with one minor modification: change "send(role)" to "send(role.name.downcase)" assuming name is the column describing the role's name in the database. 
+
+```ruby
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    @user = user || User.new # for guest
+    @user.roles.each { |role| send(role.name.downcase) }
+
+    if @user.roles.size == 0
+      can :read, :all #for guest without roles
+    end
+  end
+
+  def manager
+    can :manage, Employee
+  end
+
+  def admin
+    manager
+    can :manage, Bill
+  end
+end
+```
+
+Here each role is a separate method which is called. You can call one role inside another to define inheritance. This assumes you have a `User#roles` method which returns an array of all roles for that user.

--- a/docs/Share-Ability-Definitions.md
+++ b/docs/Share-Ability-Definitions.md
@@ -1,0 +1,9 @@
+Let's say the ability of one action depends on the ability of another. For example, what if we have a `Project` which `has_many :tasks` and we want a task's update ability to be dependent on whether the user can update the project. We can perform the `can?` call within the ability definition to check the project permission.
+
+```ruby
+can :update, Task do |task|
+  can?(:update, task.project)
+end
+```
+
+With this it is easy to define one ability based on another.

--- a/docs/Strong-Parameters.md
+++ b/docs/Strong-Parameters.md
@@ -1,0 +1,140 @@
+CanCanCan supports Strong Parameters without controller workarounds. 
+When using strong_parameters or Rails 4+, you have to sanitize inputs before saving the record, in actions such as `:create` and `:update`.
+
+By default, CanCanCan will try to sanitize the input on `:create` and `:update` routes by seeing if your controller will respond to the following methods (in order):
+
+### By Action
+
+If you specify a `create_params` or `update_params` method, CanCan will run that method depending on the action you are performing.
+
+```ruby
+class ArticlesController < ApplicationController
+  load_and_authorize_resource
+
+  def create
+    if @article.save
+      # hurray
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @article.update_attributes(update_params)
+      # hurray
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def create_params
+    params.require(:article).permit(:name, :email)
+  end
+
+  def update_params
+    params.require(:article).permit(:name)
+  end
+end
+```
+
+### By Model Name
+
+If you follow the convention in rails for naming your param method after the applicable model's class `<model_name>_params` such as `article_params`, CanCanCan will automatically detect and run that params method.
+
+```ruby
+class ArticlesController < ApplicationController
+  load_and_authorize_resource
+
+  def create
+    if @article.save
+      # hurray
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def article_params
+    params.require(:article).permit(:name)
+  end
+end
+```
+
+#### When Model and Controller names differ
+
+When you specify `class` option note that the method will still be `articles_params` and not `post_params`, since we are in `ArticlesController`.
+
+```ruby
+class ArticlesController < ApplicationController
+  load_and_authorize_resource class: 'Post'
+
+  def create
+    if @article.save
+      # hurray
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def article_params
+    params.require(:article).permit(:name)
+  end
+end
+```
+
+### By Static Method Name
+
+CanCanCan also recognizes a static method name: `resource_params`, as a general param method name you can use to standardize on.
+
+```ruby
+class ArticlesController < ApplicationController
+  load_and_authorize_resource
+
+  def create
+    if @article.save
+      # hurray
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def resource_params
+    params.require(:article).permit(:name)
+  end
+end
+```
+
+### By Custom Method
+
+Additionally, load_and_authorize_resource can now take a `param_method` option to specify a custom method in the controller to run to sanitize input.
+
+```ruby
+class ArticlesController < ApplicationController
+  load_and_authorize_resource param_method: :my_sanitizer
+
+  def create
+    if @article.save
+      # hurray
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def my_sanitizer
+    params.require(:article).permit(:name)
+  end
+end
+```
+
+### No Strong Parameters
+
+No problem, if your controllers do not respond to any of the above methods, it will ignore and continue execution as normal.

--- a/docs/Testing-Abilities.md
+++ b/docs/Testing-Abilities.md
@@ -1,0 +1,99 @@
+It can be difficult to thoroughly test user permissions at the functional/integration level because there are often many branching possibilities. Since CanCanCan handles all permission logic in `Ability` classes this makes it easy to have a solid set of unit test for complete coverage.
+
+The `can?` method can be called directly on any `Ability` (like you would in the controller or view) so it is easy to test permission logic.
+
+```ruby
+test "user can only destroy projects which they own" do
+  user = User.create!
+  ability = Ability.new(user)
+  assert ability.can?(:destroy, Project.new(user: user))
+  assert ability.cannot?(:destroy, Project.new)
+end
+```
+
+
+## RSpec
+
+If you are testing the `Ability` class through RSpec there is a `be_able_to` matcher available. This checks if the `can?` method returns `true`.
+
+```ruby
+require "cancan/matchers"
+# ...
+ability.should be_able_to(:destroy, Project.new(user: user))
+ability.should_not be_able_to(:destroy, Project.new)
+```
+
+Pro way ;)
+
+```ruby
+require "cancan/matchers"
+# ...
+describe "User" do
+  describe "abilities" do
+    subject(:ability) { Ability.new(user) }
+    let(:user){ nil }
+
+    context "when is an account manager" do
+      let(:user){ Factory(:accounts_manager) }
+
+      it { is_expected.to be_able_to(:manage, Account.new) }
+    end
+  end
+end
+```
+
+## Cucumber
+
+By default, Cucumber will ignore the `rescue_from` call in the `ApplicationController` and report the `CanCan::AccessDenied` exception when running the features. If you want full integration testing you can change this behavior so the exception is caught by Rails. You can do so by setting this in the `env.rb` file.
+
+```ruby
+# in features/support/env.rb
+ActionController::Base.allow_rescue = true
+```
+
+Alternatively, if you don't want to allow rescue on everything, you can tag individual scenarios with `@allow-rescue` tag.
+
+```ruby
+@allow-rescue
+Scenario: Update Article
+```
+
+Here the `rescue_from` block will take effect only in this scenario.
+
+
+## Controller Testing
+
+If you want to test authorization functionality at the controller level one option is to log-in the user who has the appropriate permissions.
+
+```ruby
+user = User.create!(admin: true)
+session[:user_id] = user.id # log in user however you like, alternatively stub `current_user` method
+get :index
+assert_template :index # render the template since they should have access
+```
+
+Alternatively, if you want to test the controller behaviour independently from what is inside the `Ability` class, it is easy to stub out the ability with any behaviour you want.
+
+```ruby
+def setup
+  @ability = Object.new
+  @ability.extend(CanCan::Ability)
+  @controller.stubs(:current_ability).returns(@ability)
+end
+
+test "render index if have read ability on project" do
+  @ability.can :read, Project
+  get :index
+  assert_template :index
+end
+```
+
+If you have very complex permissions it can lead to many branching possibilities. If these are all tested in the controller layer then it can lead to slow and bloated tests. 
+Instead I recommend keeping controller authorization tests light and testing the authorization functionality more thoroughly in the Ability model through unit tests as shown at the top.
+
+## Additional Docs
+
+* [[Defining Abilities]]
+* [[Checking Abilities]]
+* [[Debugging Abilities]]
+* [[Ability Precedence]]

--- a/docs/Translations-(i18n).md
+++ b/docs/Translations-(i18n).md
@@ -1,0 +1,49 @@
+To use translations in your app define some yaml like this:
+```yaml
+# en.yml
+en:
+  unauthorized:
+    manage:
+      all: "You have no access to this resource"
+```
+## Translation for individual abilities
+If you want to customize messages for some model or even for some ability define translation like this:
+
+```ruby
+# models/ability.rb
+...
+can :create, Article
+...
+```
+```yaml
+# en.yml
+en:
+  unauthorized:
+    create:
+      article: "Only an admin can create an article"
+```
+
+### Translating custom abilities
+Also translations is available for your custom abilities:
+```ruby
+# models/ability.rb
+...
+can :vote, Article
+...
+```
+```yaml
+# en.yml
+en:
+  unauthorized:
+    vote:
+      article: "Only users which have one or more article can vote"
+```
+## Variables for translations
+Finally you may use `action`(which contain ability like 'create') and `subject`(for example 'article') variables in your translation:
+```yaml
+# en.yml
+en:
+  unauthorized:
+    manage:
+      all: "You do not have access to %{action} %{subject}!"
+```

--- a/docs/mvc--deficiencies.md
+++ b/docs/mvc--deficiencies.md
@@ -1,0 +1,15 @@
+Hi all, First I like cancan because it collects all resource access rules in one place, but !
+
+Although there are many benefits to mvc frameworks (mainly to large dev teams), there are of course short comings.
+
+So, you have an app with user roles and define access to resources using cancan.  Then because of mvc you have to search all your views that render links to these protected resources. This creates a lot of unnecessary noise and is not very DRY. 
+
+It seems to me that it would be simpler if the rules created in cancan automatically generated override filters (perhaps using deface) that warden could utilise so that these useless links are removed from the rendered html.
+
+What do you think ?
+
+I would call the approach mvc+ and define it such that the only legitimate use cases are those that have one requirement that has a common effect across all mvc domains (like user roles and access rights to resources).
+ 
+I would love to create a solution but although I have 30 years as a self employed software engineer I am not fully up to speed with the rights and wrongs of the finer detail within the rails framework.
+
+Any suggestions ! 


### PR DESCRIPTION
Solves #607

> This has happened because the Wiki was completely out of control and became a huge mess. I'd be happy to move all the documentation within the repository in a docs folder, so that people can help maintaining the documentation by opening PR. If you feel like, you could help us by moving one page per time. This would help a lot heart

I have moved all the wiki docs into a separate folder called docs with this PR.

