### PR TITLE
Disable to pass rule with class subject with block or condition

### DIFF
--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -19,7 +19,8 @@ module CanCan
     end
 
     def matches_block_conditions(subject, *extra_args)
-      return @base_behavior if subject_class?(subject)
+      # we cannot process block for class subject (block is working with instance), so if we don't know what is result of block we are returning false
+      return false if subject_class?(subject)
 
       @block.call(subject, *extra_args.compact)
     end
@@ -28,8 +29,8 @@ module CanCan
       return nested_subject_matches_conditions?(subject) if subject.class == Hash
       return matches_conditions_hash?(subject) unless subject_class?(subject)
 
-      # Don't stop at "cannot" definitions when there are conditions.
-      @base_behavior
+      # we did not match conditions, so if condition is not true we are returning false
+      false
     end
 
     def nested_subject_matches_conditions?(subject_hash)

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -25,7 +25,7 @@ describe CanCan::Ability do
     expect(@ability.can?(:read, :some_symbol)).to be(true)
   end
 
-  it 'passes nothing to a block when no instance is passed' do
+  it 'does not call a block when no instance is passed, and returns false' do
     @block_called = false
     @ability.can :read, Symbol do |sym|
       @block_called = true
@@ -837,7 +837,7 @@ describe CanCan::Ability do
       @ability.can :index, user_class do |_object|
         @block_called = true
       end
-      expect(@ability.can?(:preview, user_class)).to be(false)
+      expect(@ability.can?(:index, user_class)).to be(false)
       expect(@block_called).to be(false)
     end
   end


### PR DESCRIPTION
fixing weird behaviour, when using block or condition in rule with class subject enables this rule for everyone, who is asking with class subject

see https://github.com/CanCanCommunity/cancancan/issues/617 for details (Actual behaviour section)

### Fixed behaviour 

```Ruby
    can(%i[read edit update destroy], Company) { |company| @user.has_role?(:manager, company.account) }
    can :index, Company if @user.roles.find_by(name: :manager, resource_type: 'Account').present?
```
- If there is only first rule, ```can? :index, Company``` will respond with **false**
- If there is also second rule, ```can? :index, Company``` will respond with **true** (if user is manager of some account)
