### PR TITLE
CI: use jruby-9.2.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.7.0
   - ruby-head
   - jruby-9.1.17.0
-  - jruby-9.2.7.0
+  - jruby-9.2.11.0
   - jruby-head
 
 gemfile:
@@ -39,9 +39,9 @@ matrix:
     gemfile: gemfiles/activerecord_5.0.2.gemfile
   - rvm: jruby-9.1.17.0
     gemfile: gemfiles/activerecord_6.0.0.gemfile
-  - rvm: jruby-9.2.7.0
+  - rvm: jruby-9.2.11.0
     gemfile: gemfiles/activerecord_5.0.2.gemfile
-  - rvm: jruby-9.2.7.0
+  - rvm: jruby-9.2.11.0
     gemfile: gemfiles/activerecord_6.0.0.gemfile
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.0**.

[JRuby 9.2.11.0 release blog post](https://www.jruby.org/2020/03/02/jruby-9-2-11-0.html)