### PR TITLE
Updated README for appraisal command.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ of Rails, as well as the different model adapters.
 
 When first developing, you need to run `bundle install` and then `appraisal install`, to install the different sets.
 
-You can then run all appraisal files (like CI does), with `appraisal rake` or just run a specific set `appraisal activerecord_5.0 rake`.
+You can then run all appraisal files (like CI does), with `appraisal rake` or just run a specific set `bundle exec appraisal activerecord_5.2.2 rake`.
 
 See the [CONTRIBUTING](https://github.com/CanCanCommunity/cancancan/blob/develop/CONTRIBUTING.md) for more information.
 


### PR DESCRIPTION
Updated to a supported version of rails (for serious security fixes).
Added 'bundle exec' to command.
Fixed version syntax.  Appraisals file has no `activerecord_5.0` line. It looks like it specifies down to the minor version:
`appraise 'activerecord_5.2.2' do`