### PR TITLE
CI: Use jruby-9.2.11.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.7.0
   - ruby-head
   - jruby-9.1.17.0
-  - jruby-9.2.11.0
+  - jruby-9.2.11.1
   - jruby-head
 
 gemfile:
@@ -38,9 +38,9 @@ matrix:
     gemfile: gemfiles/activerecord_5.0.2.gemfile
   - rvm: jruby-9.1.17.0
     gemfile: gemfiles/activerecord_6.0.0.gemfile
-  - rvm: jruby-9.2.11.0
+  - rvm: jruby-9.2.11.1
     gemfile: gemfiles/activerecord_5.0.2.gemfile
-  - rvm: jruby-9.2.11.0
+  - rvm: jruby-9.2.11.1
     gemfile: gemfiles/activerecord_6.0.0.gemfile
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.11.1**.

[JRuby 9.2.11.1 release blog post](https://www.jruby.org/2020/03/25/jruby-9-2-11-1.html)