### PR TITLE
Add #inspect on AccessDenied error

### DIFF
--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -58,5 +58,13 @@ module CanCan
     def to_s
       @message || @default_message
     end
+
+    def inspect
+      details = %i[action subject conditions message].map do |attribute|
+        value = instance_variable_get "@#{attribute}"
+        "#{attribute}: #{value.inspect}" if value.present?
+      end.compact.join(', ')
+      "#<#{self.class.name} #{details}>"
+    end
   end
 end

--- a/spec/cancan/exceptions_spec.rb
+++ b/spec/cancan/exceptions_spec.rb
@@ -19,6 +19,12 @@ describe CanCan::AccessDenied do
       @exception.default_message = 'Unauthorized!'
       expect(@exception.message).to eq('Unauthorized!')
     end
+
+    it 'has debug information on inspect' do
+      expect(@exception.inspect).to eq(
+        '#<CanCan::AccessDenied action: :some_action, subject: :some_subject, conditions: :some_conditions>'
+      )
+    end
   end
 
   describe 'with only a message' do


### PR DESCRIPTION
Access denied errors use the message attribute to help the end user (not the developer) making debugging those errors trickier, as most information is not there.

This PR adds a custom `inspect` method intended for developers, with lot of debugging information.