### PR TITLE
Insert new model adapters at the start of the list

### DIFF
--- a/lib/cancan/model_adapters/abstract_adapter.rb
+++ b/lib/cancan/model_adapters/abstract_adapter.rb
@@ -5,7 +5,7 @@ module CanCan
     class AbstractAdapter
       def self.inherited(subclass)
         @subclasses ||= []
-        @subclasses << subclass
+        @subclasses.insert(0, subclass)
       end
 
       def self.adapter_class(model_class)


### PR DESCRIPTION
This makes implementing new [model adapters](https://github.com/CanCanCommunity/cancancan/blob/develop/docs/Model-Adapter.md) easier. The example in the docs adds an adapter for non-activerecord. That works fine - none of the builtin adapters will work with it. But consider the use case where you want to add a more specific adapter for activerecord, and don't want to fork cancancan.

```ruby
module CanCan
  module ModelAdapters
    class IDProxyAdapter < ActiveRecord5Adapter
      AbstractAdapter.inherited(self)

      def self.for_class?(model_class)
        super
      end
```

Currently this will not work, because `IDProxyAdapter` will come after `ActiveRecord5Adapter` in [`CanCan::ModelAdapters::AbstractAdapters#subclasses`](https://github.com/CanCanCommunity/cancancan/blob/develop/lib/cancan/model_adapters/abstract_adapter.rb#L12). So `ActiveRecord5Adapter` will always get used.

By adding new adapters to the start of the subclasses list, we inverse this. All the builtin adapters will end up last in the list; all adapters added in userland will be considered first.

This is safe with all built in adapters because they are written in an exclusive way ([AR4](https://github.com/CanCanCommunity/cancancan/blob/develop/lib/cancan/model_adapters/active_record_4_adapter.rb#L10), [AR5](https://github.com/CanCanCommunity/cancancan/blob/develop/lib/cancan/model_adapters/active_record_5_adapter.rb#L9)). As a result, no tests should break here. However, this _could_ cause problems for users who have added AR adapters in the wild if they haven't added to them the start of the `subclasses` list. For that reason I think this should be considered a breaking change.

If this is accepted I'm happy to also tidy up the docs to make it more clear how easy adapters are to add.