### PR TITLE
Feature/fix subclass check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [#532](https://github.com/CanCanCommunity/cancancan/issues/532): Generate inner queries instead of join+distinct. ([@mraidel][], [@gabsi20][])
+
 ## 3.1.0
 
 * [#605](https://github.com/CanCanCommunity/cancancan/pull/605): Generate inner queries instead of join+distinct. ([@fsateler][])
@@ -665,3 +669,4 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@aleksejleonov]: https://github.com/aleksejleonov
 [@albb0920]: https://github.com/albb0920
 [@ayumu838]: https://github.com/ayumu838
+[@liberatys]: https://github.com/liberatys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-* [#532](https://github.com/CanCanCommunity/cancancan/issues/532): Generate inner queries instead of join+distinct. ([@mraidel][], [@gabsi20][])
-
 ## 3.1.0
 
 * [#605](https://github.com/CanCanCommunity/cancancan/pull/605): Generate inner queries instead of join+distinct. ([@fsateler][])
@@ -669,4 +665,3 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@aleksejleonov]: https://github.com/aleksejleonov
 [@albb0920]: https://github.com/albb0920
 [@ayumu838]: https://github.com/ayumu838
-[@liberatys]: https://github.com/liberatys

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -302,7 +302,7 @@ module CanCan
 
     def alternative_subjects(subject)
       subject = subject.class unless subject.is_a?(Module)
-      if subject.respond_to?(:subclasses)
+      if subject.respond_to?(:subclasses) && subject < (ActiveRecord::Base)
         [:all, *(subject.ancestors + subject.subclasses), subject.class.to_s]
       else
         [:all, *subject.ancestors, subject.class.to_s]

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -302,7 +302,7 @@ module CanCan
 
     def alternative_subjects(subject)
       subject = subject.class unless subject.is_a?(Module)
-      if subject.respond_to?(:subclasses) && subject < (ActiveRecord::Base)
+      if subject.respond_to?(:subclasses) && subject < ActiveRecord::Base
         [:all, *(subject.ancestors + subject.subclasses), subject.class.to_s]
       else
         [:all, *subject.ancestors, subject.class.to_s]


### PR DESCRIPTION
This addresses an issue with bigger projects, where classes have a big inheritance structure and thus the collection of subclasses is taking longer than is feasible. 

Introduce a guard to check if given element is inheriting from ActiveRecord::Base. Otherwise subclasses will not be collected because they are only needed in the process of creating sti connections.

The check with "<" should work, as you can not instantiate ActiveRecord::Base. Thus <= is not needed.

----

Adresses #659

cc @coorasse 