### PR TITLE
conflicting STI rules

### DIFF
--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -731,5 +731,25 @@ WHERE "articles"."published" = #{false_v} AND "articles"."secret" = #{true_v}))
       expect(ability).to be_able_to(:read, motorbike)
       expect(ability).to be_able_to(:read, Suzuki.new)
     end
+
+    it 'recognises conflicting rules' do
+      u1 = User.create!(name: 'pippo')
+      car = Car.create!
+      motorbike = Motorbike.create!
+      suzuki = Suzuki.create!
+
+      ability = Ability.new(u1)
+      ability.can :read, Vehicle
+      ability.cannot :read, Motorbike
+
+      expect(ability).to be_able_to(:read, car)
+      expect(ability).to_not be_able_to(:read, motorbike)
+      expect(ability).to_not be_able_to(:read, suzuki)
+
+      expect(Vehicle.accessible_by(ability)).to match_array([car])
+      expect(Car.accessible_by(ability)).to match_array([car])
+      expect(Motorbike.accessible_by(ability)).to match_array([])
+      expect(Suzuki.accessible_by(ability)).to match_array([])
+    end
   end
 end


### PR DESCRIPTION
This PR addresses an issue where conditions are not correctly generated for conflicting STI rules. 

See (currently failing) test here:

https://github.com/tomasc/cancancan/blob/conflicting-sti-rules/spec/cancan/model_adapters/active_record_adapter_spec.rb#L735-L753

I tried to come up with a way to fix this, but on luck so far. Help would be appreciated!