### PR TITLE
Allow array inside alias_action

### DIFF
--- a/lib/cancan/ability/actions.rb
+++ b/lib/cancan/ability/actions.rb
@@ -33,6 +33,7 @@ module CanCan
       #
       # This way one can use params[:action] in the controller to determine the permission.
       def alias_action(*args)
+        args.flatten!
         target = args.pop[:to]
         validate_target(target)
         aliased_actions[target] ||= []


### PR DESCRIPTION
Allows for specifying ```[ ]``` around your aliased actions.  

```alias_action [:read, :create], :to :crud```