### PR TITLE
WIP

### DIFF
--- a/lib/cancan/class_matcher.rb
+++ b/lib/cancan/class_matcher.rb
@@ -4,22 +4,18 @@
 class SubjectClassMatcher
   def self.matches_subject_class?(subjects, subject)
     subjects.any? do |sub|
-      has_subclasses = subject.respond_to?(:subclasses)
-      matching_class_check(subject, sub, has_subclasses)
+      matching_class_check(subject, sub)
     end
   end
 
-  def self.matching_class_check(subject, sub, has_subclasses)
-    matches = matches_class_or_is_related(subject, sub)
-    if has_subclasses
-      matches || subject.subclasses.include?(sub)
-    else
-      matches
-    end
+  def self.matching_class_check(subject, sub)
+    matches_class_or_is_related(subject, sub)
   end
 
   def self.matches_class_or_is_related(subject, sub)
-    sub.is_a?(Module) && (subject.is_a?(sub) ||
+    return false unless sub.is_a?(Module)
+
+    (subject.is_a?(sub) ||
         subject.class.to_s == sub.to_s ||
         (subject.is_a?(Module) && subject.ancestors.include?(sub)))
   end

--- a/lib/cancan/model_adapters/sti_normalizer.rb
+++ b/lib/cancan/model_adapters/sti_normalizer.rb
@@ -30,7 +30,7 @@ module CanCan
 
         # create a new rule for the subclasses that links on the inheritance_column
         def build_rule_for_subclass(rule, subject)
-          CanCan::Rule.new(rule.base_behavior, rule.actions, subject.superclass,
+          CanCan::Rule.new(rule.base_behavior, rule.actions, subject,
                            rule.conditions.merge(subject.inheritance_column => subject.name), rule.block)
         end
       end

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -966,14 +966,14 @@ describe CanCan::ModelAdapters::ActiveRecordAdapter do
       expect(Suzuki.accessible_by(ability)).to match_array([suzuki])
     end
 
-    it 'recognises rules applied to subclasses' do
+    it 'does not recognise rules applied to subclasses' do
       u1 = User.create!(name: 'pippo')
       car = Car.create!
       Motorbike.create!
 
       ability = Ability.new(u1)
       ability.can :read, [Car]
-      expect(Vehicle.accessible_by(ability)).to match_array([car])
+      expect(Vehicle.accessible_by(ability)).to match_array([])
       expect(Car.accessible_by(ability)).to eq([car])
       expect(Motorbike.accessible_by(ability)).to eq([])
     end
@@ -984,7 +984,7 @@ describe CanCan::ModelAdapters::ActiveRecordAdapter do
       Motorbike.create!
       ability = Ability.new(u1)
       ability.can :read, [Suzuki]
-      expect(Motorbike.accessible_by(ability)).to eq([suzuki])
+      expect(Motorbike.accessible_by(ability)).not_to eq([suzuki])
     end
 
     it 'recognises rules applied to subclass of subclass even with be_able_to' do
@@ -994,6 +994,13 @@ describe CanCan::ModelAdapters::ActiveRecordAdapter do
       ability.can :read, [Motorbike]
       expect(ability).to be_able_to(:read, motorbike)
       expect(ability).to be_able_to(:read, Suzuki.new)
+    end
+    it 'does not effect parent definition with rules' do
+      u1 = User.create!(name: 'pippo')
+      ability = Ability.new(u1)
+      ability.can :manage, [Suzuki]
+      expect(ability).to be_able_to(:manage, Suzuki)
+      expect(ability).not_to be_able_to(:manage, Motorbike)
     end
   end
 end


### PR DESCRIPTION
* Remove the application of rules to a parent when applied to a subclass

This pr addresses the issue outline in #677.

I'm wondering if this also partially applies to: https://github.com/CanCanCommunity/cancancan/pull/663.

The issue there is the following:

`Ability:
	can read Vehicle
	cannot read Motorbike

Now the Vehicle is accesible_by car, motorcycle and suzuki.

`