### PR TITLE
Use `relation.and` instead of `relation.merge` whenever possible.

### DIFF
--- a/lib/cancan.rb
+++ b/lib/cancan.rb
@@ -21,4 +21,5 @@ if defined? ActiveRecord
   require 'cancan/model_adapters/active_record_adapter'
   require 'cancan/model_adapters/active_record_4_adapter'
   require 'cancan/model_adapters/active_record_5_adapter'
+  require 'cancan/model_adapters/active_record_61_adapter'
 end

--- a/lib/cancan/model_adapters/active_record_5_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_5_adapter.rb
@@ -6,7 +6,7 @@ module CanCan
       AbstractAdapter.inherited(self)
 
       def self.for_class?(model_class)
-        version_greater_or_equal?('5.0.0') && model_class <= ActiveRecord::Base
+        version_greater_or_equal?('5.0.0') && version_lower?('6.1.0') && model_class <= ActiveRecord::Base
       end
 
       # rails 5 is capable of using strings in enum

--- a/lib/cancan/model_adapters/active_record_61_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_61_adapter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CanCan
+  module ModelAdapters
+    class ActiveRecord61Adapter < ActiveRecord5Adapter
+      AbstractAdapter.inherited(self)
+
+      def self.for_class?(model_class)
+        version_greater_or_equal?('6.1.0') && model_class <= ActiveRecord::Base
+      end
+
+      # rails 6.1 introduced `relation.and`
+      # which is more suitable for intersecting two relations then `relation.merge`
+      def database_records
+        return super unless override_scope
+
+        if @model_class.all.send(:structurally_incompatible_values_for, override_scope).empty?
+          @model_class.and(override_scope)
+        else
+          # wrap both side in subqeruy to satisfy structural compatibility requirements
+          wrap_model_subquery(@model_class.all).and(wrap_model_subquery(override_scope))
+        end
+      end
+
+      private
+
+      def wrap_model_subquery(scope)
+        real_model_class = @model_class.all.klass
+
+        real_model_class.where(real_model_class.primary_key => scope)
+      end
+    end
+  end
+end

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -134,7 +134,12 @@ describe CanCan::ModelAdapters::ActiveRecordAdapter do
       end
 
       it 'is for only active record classes' do
-        if ActiveRecord.version > Gem::Version.new('5')
+        if ActiveRecord.version > Gem::Version.new('6.1')
+          expect(CanCan::ModelAdapters::ActiveRecord61Adapter).to_not be_for_class(Object)
+          expect(CanCan::ModelAdapters::ActiveRecord61Adapter).to be_for_class(Article)
+          expect(CanCan::ModelAdapters::AbstractAdapter.adapter_class(Article))
+            .to eq(CanCan::ModelAdapters::ActiveRecord61Adapter)
+        elsif ActiveRecord.version > Gem::Version.new('5')
           expect(CanCan::ModelAdapters::ActiveRecord5Adapter).to_not be_for_class(Object)
           expect(CanCan::ModelAdapters::ActiveRecord5Adapter).to be_for_class(Article)
           expect(CanCan::ModelAdapters::AbstractAdapter.adapter_class(Article))


### PR DESCRIPTION
Currently cancancan uses `relation.merge` to apply scope in ability rule to the scope of `load_resource through`.
However, since `relation.merge` intends to mimics Hash#merge,
(i.e. later condition on the same column replaces the previous one), 
this causes the `load_resource through` become ineffective when the scope in ability also specifics conditions on the same column.

This PR adds model adapter for activerecord >= 6.1 and overrides `database_records` to use `relation.and` instead. It also tries to keep the query simple by only wrapping scopes to sub queries only when necessary, which relies on private ActiveRecord API `structurally_incompatible_values_for`

## Example: 
ability file:
```ruby
can :manage, Group

can :manage, Post, Post.where(group_id: user.groups) do |post|
  post.gorup.users.exists?(user.id)
end
```

controller:
```ruby
class PostsController < ApplicationController
  load_and_authorize_resource :group
  load_and_authorize_resource through: :group
  
  def index
    # @posts will be from all groups,
    # as the condition for Post#group_id setted on `load_and_authorize_resource through`
    # is replaced by the condition specified in ability rule during relation.merge 
  end
end
```

## References
For more information on the behavior of `relation.merge` and `relation.and` that was introduced in rails 6.1,
please refer to rails/rails#39250 & rails/rails#40944