### PR TITLE
Fix name in CI exclude

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             ruby: '2.7' # rails 4.2 can't run on ruby 2.7 due to BigDecimal API change
           - gemfile: 'gemfiles/activerecord_4.2.0.gemfile'
             ruby: 'truffleruby' # TruffleRuby 21.0 targets Ruby 2.7, same as above
+          - gemfile: 'gemfiles/activerecord_master.gemfile'
+            ruby: 'truffleruby' # rails master might need truffleruby-head
           - gemfile: 'gemfiles/activerecord_6.0.0.gemfile'
             ruby: '2.4' # rails 6+ requires ruby 2.5+
           - gemfile: 'gemfiles/activerecord_6.1.0.gemfile'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - gemfile: 'gemfiles/activerecord_4.2.0.gemfile'
             ruby: '2.7' # rails 4.2 can't run on ruby 2.7 due to BigDecimal API change
           - gemfile: 'gemfiles/activerecord_4.2.0.gemfile'
-            ruby: '2.7' # TruffleRuby 21.0 targets Ruby 2.7, same as above
+            ruby: 'truffleruby' # TruffleRuby 21.0 targets Ruby 2.7, same as above
           - gemfile: 'gemfiles/activerecord_6.0.0.gemfile'
             ruby: '2.4' # rails 6+ requires ruby 2.5+
           - gemfile: 'gemfiles/activerecord_6.1.0.gemfile'


### PR DESCRIPTION
I noticed I forgot to change the name for `ruby:` in the exclude line added in https://github.com/CanCanCommunity/cancancan/pull/682.
Now it should be good :)