### PR TITLE
[WIP] Introduce load_and_authorize_resource! alias

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,3 @@
-appraise 'activerecord_4.2.0' do
-  gem 'activerecord', '~> 4.2.0', require: 'active_record'
-  gem 'activesupport', '~> 4.2.0', require: 'active_support/all'
-  gem 'actionpack', '~> 4.2.0', require: 'action_pack'
-  gem 'nokogiri', '~> 1.6.8', require: 'nokogiri' # TODO: fix for ruby 2.0.0
-
-  gemfile.platforms :jruby do
-    gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.24'
-    gem 'jdbc-sqlite3'
-    gem 'jdbc-postgres'
-  end
-
-  gemfile.platforms :ruby, :mswin, :mingw do
-    gem 'sqlite3', '~> 1.3.0'
-    gem 'pg', '~> 0.21'
-  end
-end
-
 appraise 'activerecord_5.0.2' do
   gem 'activerecord', '~> 5.0.2', require: 'active_record'
   gem 'activesupport', '~> 5.0.2', require: 'active_support/all'

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ end
 
 ### 3.2 Loaders
 
-Setting this for every action can be tedious, therefore the `load_and_authorize_resource` method is provided to
+Setting this for every action can be tedious, therefore the `load_and_authorize_resource!` method is provided to
 automatically authorize all actions in a RESTful style resource controller.
 It will use a before action to load the resource into an instance variable and authorize it for every action.
 
 ```ruby
 class PostsController < ApplicationController
-  load_and_authorize_resource
+  load_and_authorize_resource!
 
   def show
     # @post is already loaded and authorized
@@ -177,13 +177,13 @@ controller will respond to the following methods (in order):
 2. `<model_name>_params` such as `post_params` (this is the default convention in rails for naming your param method)
 3. `resource_params` (a generically named method you could specify in each controller)
 
-Additionally, `load_and_authorize_resource` can now take a `param_method` option to specify a custom method in the controller to run to sanitize input.
+Additionally, `load_and_authorize_resource!` can now take a `param_method` option to specify a custom method in the controller to run to sanitize input.
 
 You can associate the `param_method` option with a symbol corresponding to the name of a method that will get called:
 
 ```ruby
 class PostsController < ApplicationController
-  load_and_authorize_resource param_method: :my_sanitizer
+  load_and_authorize_resource! param_method: :my_sanitizer
 
   def create
     if @post.save
@@ -203,11 +203,11 @@ end
 
 You can also use a string that will be evaluated in the context of the controller using `instance_eval` and needs to contain valid Ruby code.
 
-    load_and_authorize_resource param_method: 'permitted_params.post'
+    load_and_authorize_resource! param_method: 'permitted_params.post'
 
 Finally, it's possible to associate `param_method` with a Proc object which will be called with the controller as the only argument:
 
-    load_and_authorize_resource param_method: Proc.new { |c| c.params.require(:post).permit(:name) }
+    load_and_authorize_resource! param_method: Proc.new { |c| c.params.require(:post).permit(:name) }
 
 See [Strong Parameters](./docs/Strong-Parameters.md) for more information.
 

--- a/docs/Authorizing-controller-actions.md
+++ b/docs/Authorizing-controller-actions.md
@@ -7,11 +7,11 @@ def show
 end
 ```
 
-However that can be tedious to apply to each action. Instead you can use the `load_and_authorize_resource` method in your controller to load the resource into an instance variable and authorize it automatically for every action in that controller.
+However that can be tedious to apply to each action. Instead you can use the `load_and_authorize_resource!` method in your controller to load the resource into an instance variable and authorize it automatically for every action in that controller.
 
 ```ruby
 class ProductsController < ActionController::Base
-  load_and_authorize_resource
+  load_and_authorize_resource!
 end
 ```
 
@@ -24,22 +24,22 @@ class ProductsController < ActionController::Base
 end
 ```
 
-As of CanCan 1.5 you can use the `skip_load_and_authorize_resource`, `skip_load_resource` or `skip_authorize_resource` methods to skip any of the applied behavior and specify specific actions like in a before filter. For example.
+As of CanCan 1.5 you can use the `skip_load_and_authorize_resource!`, `skip_load_resource` or `skip_authorize_resource` methods to skip any of the applied behavior and specify specific actions like in a before filter. For example.
 
 ```ruby
 class ProductsController < ActionController::Base
-  load_and_authorize_resource
+  load_and_authorize_resource!
   skip_authorize_resource :only => :new
 end
 ```
 
 **important notice about `:manage` rules**
 
-Using `load_and_authorize_resource` with a rule like `can :manage, Article, id: 23` will allow rendering the `new` method of the ArticlesController, which is unexpected because this rule naively reads as _"the user can manage the existing article with id 23"_, which should have nothing to do with creating new articles.
+Using `load_and_authorize_resource!` with a rule like `can :manage, Article, id: 23` will allow rendering the `new` method of the ArticlesController, which is unexpected because this rule naively reads as _"the user can manage the existing article with id 23"_, which should have nothing to do with creating new articles.
 
 But in reality the rule means _"the user can manage any article object with an id field set to 23"_, which includes creating a new Article with the id set to 23 like `Article.new(id: 23)`.
 
-Thus `load_and_authorize_resource` will initialize a model in the `:new` action and set its id to 23, and happily render the page. Saving will not work though.
+Thus `load_and_authorize_resource!` will initialize a model in the `:new` action and set its id to 23, and happily render the page. Saving will not work though.
 
 The correct intended rule to avoid `new` being allowed would be:
 
@@ -56,7 +56,7 @@ By default this will apply to **every action** in the controller even if it is n
 
 ```ruby
 class ProductsController < ActionController::Base
-  load_and_authorize_resource
+  load_and_authorize_resource!
   def discontinue
     # Automatically does the following:
     # @product = Product.find(params[:id])
@@ -68,7 +68,7 @@ end
 You can specify which actions to affect using the `:except` and `:only` options, just like a `before_action`.
 
 ```ruby
-load_and_authorize_resource :only => [:index, :show]
+load_and_authorize_resource! :only => [:index, :show]
 ```
 ### Choosing actions on nested resources 
 
@@ -76,8 +76,8 @@ For this you can pass a name to skip_authorize_resource.
 For example:
 ```ruby
 class CommentsController < ApplicationController
-  load_and_authorize_resource :post
-  load_and_authorize_resource :through => :post
+  load_and_authorize_resource! :post
+  load_and_authorize_resource! :through => :post
 
   skip_authorize_resource :only => :show  
   skip_authorize_resource :post, :only => :show
@@ -142,7 +142,7 @@ If the model is named differently than the controller, then you may explicitly n
 
 ```ruby
 class ArticlesController < ApplicationController
-  load_and_authorize_resource :post, :parent => false
+  load_and_authorize_resource! :post, :parent => false
 end
 ```
 
@@ -150,7 +150,7 @@ If the model class is namespaced differently than the controller you will need t
 
 ```ruby
 class ProductsController < ApplicationController
-  load_and_authorize_resource :class => "Store::Product"
+  load_and_authorize_resource! :class => "Store::Product"
 end
 ```
 
@@ -171,7 +171,7 @@ The resource will only be loaded into an instance variable if it hasn't been alr
 ```ruby
 class BooksController < ApplicationController
   before_action :find_published_book, :only => :show
-  load_and_authorize_resource
+  load_and_authorize_resource!
 
   private
 
@@ -181,7 +181,7 @@ class BooksController < ApplicationController
 end
 ```
 
-It is important that any custom loading behavior happens **before** the call to `load_and_authorize_resource`. If you have `authorize_resource` in your `ApplicationController` then you need to use `prepend_before_action` to do the loading in the controller subclasses so it happens before authorization.
+It is important that any custom loading behavior happens **before** the call to `load_and_authorize_resource!`. If you have `authorize_resource` in your `ApplicationController` then you need to use `prepend_before_action` to do the loading in the controller subclasses so it happens before authorization.
 
 ## authorize_resource
 

--- a/docs/Controller-Authorization-Example.md
+++ b/docs/Controller-Authorization-Example.md
@@ -1,8 +1,8 @@
-CanCan provides a convenient `load_and_authorize_resource` method in the controller, but what exactly is this doing? It sets up a before filter for every action to handle the loading and authorization of the controller. Let's say we have a typical RESTful controller with that line at the top.
+CanCan provides a convenient `load_and_authorize_resource!` method in the controller, but what exactly is this doing? It sets up a before filter for every action to handle the loading and authorization of the controller. Let's say we have a typical RESTful controller with that line at the top.
 
 ```ruby
 class ProjectsController < ApplicationController
-  load_and_authorize_resource
+  load_and_authorize_resource!
   # ...
 end
 ```
@@ -67,4 +67,4 @@ end
 
 The most complex behavior is inside the new and create actions. There it is setting some initial attribute values based on what the given user has permission to access. For example, if the user is only allowed to create projects where the "visible" attribute is true, then it would automatically set this upon building it.
 
-See [[Authorizing Controller Actions]] for details on what options you can pass to the `load_and_authorize_resource`.
+See [[Authorizing Controller Actions]] for details on what options you can pass to the `load_and_authorize_resource!`.

--- a/docs/Exception-Handling.md
+++ b/docs/Exception-Handling.md
@@ -87,7 +87,7 @@ end
 
 Please read [this thread](https://github.com/CanCanCommunity/cancancan/issues/437) for more information.
 
-In a Rails application, if a record is not found during `load_and_authorize_resource` it raises `ActiveRecord::NotFound` before it checks _authentication_ in the `authorize` step.
+In a Rails application, if a record is not found during `load_and_authorize_resource!` it raises `ActiveRecord::NotFound` before it checks _authentication_ in the `authorize` step.
 
 This means that secured routes can have their resources discovered without even being signed in:
 

--- a/docs/Inherited-Resources.md
+++ b/docs/Inherited-Resources.md
@@ -1,11 +1,11 @@
 **This guide is for cancancan < 2.0 only.
 If you want to use Inherited Resources and cancancan 2.0 please check for extensions like https://github.com/TylerRick/cancan-inherited_resources**
 
-The `load_and_authorize_resource` call will automatically detect if you are using [[Inherited Resources|http://github.com/josevalim/inherited_resources]] and load the resource through that. The `load` part in CanCan is still necessary since Inherited Resources does lazy loading. This will also ensure the behavior is identical to normal loading.
+The `load_and_authorize_resource!` call will automatically detect if you are using [[Inherited Resources|http://github.com/josevalim/inherited_resources]] and load the resource through that. The `load` part in CanCan is still necessary since Inherited Resources does lazy loading. This will also ensure the behavior is identical to normal loading.
 
 ```ruby
 class ProjectsController < InheritedResources::Base
-  load_and_authorize_resource
+  load_and_authorize_resource!
 end
 ```
 
@@ -14,17 +14,17 @@ if you are doing nesting you will need to mention it in both Inherited Resources
 ```ruby
 class TasksController < InheritedResources::Base
   belongs_to :project
-  load_and_authorize_resource :project
-  load_and_authorize_resource :task, :through => :project
+  load_and_authorize_resource! :project
+  load_and_authorize_resource! :task, :through => :project
 end
 ```
-<i>Please note that even for a `has_many :tasks` association, the `load_and_authorize_resource` needs the singular name of the associated model...</i>
+<i>Please note that even for a `has_many :tasks` association, the `load_and_authorize_resource!` needs the singular name of the associated model...</i>
 
-**Warning**: when overwriting the `collection` method in a controller the `load` part of a `load_and_authorize_resource` call will not work correctly. See https://github.com/ryanb/cancan/issues/274 for the discussions. 
+**Warning**: when overwriting the `collection` method in a controller the `load` part of a `load_and_authorize_resource!` call will not work correctly. See https://github.com/ryanb/cancan/issues/274 for the discussions. 
 
 In this case you can override collection like
 ```ruby
-skip_load_and_authorize_resource :only => :index
+skip_load_and_authorize_resource! :only => :index
 
 def collection
   @products ||= end_of_association_chain.accessible_by(current_ability).paginate(:page => params[:page], :per_page => 10)
@@ -37,6 +37,6 @@ With mongoid it is necessary to reference `:project_id` instead of just `:projec
 ```ruby
 class TasksController < InheritedResources::Base
   ...
-  load_and_authorize_resource :task, :through => :project_id
+  load_and_authorize_resource! :task, :through => :project_id
 end
 ```

--- a/docs/Nested-Resources.md
+++ b/docs/Nested-Resources.md
@@ -10,8 +10,8 @@ We can then tell CanCanCan to load the project and then load the task through th
 
 ```ruby
 class TasksController < ApplicationController
-  load_and_authorize_resource :project
-  load_and_authorize_resource :task, through: :project
+  load_and_authorize_resource! :project
+  load_and_authorize_resource! :task, through: :project
 end
 ```
 
@@ -21,8 +21,8 @@ If the name of the association doesn't match the resource name, for instance `ha
 
 ```ruby
   class TasksController < ApplicationController
-    load_and_authorize_resource :project
-    load_and_authorize_resource :task, through: :project, through_association: :issues
+    load_and_authorize_resource! :project
+    load_and_authorize_resource! :task, through: :project, through_association: :issues
   end
 ```
 
@@ -35,7 +35,7 @@ It's also possible to nest through a method, this is commonly the `current_user`
 
 ```ruby
 class ProjectsController < ApplicationController
-  load_and_authorize_resource through: :current_user
+  load_and_authorize_resource! through: :current_user
 end
 ```
 
@@ -48,8 +48,8 @@ If you want it to be optional (such as with shallow routes), add the `shallow: t
 
 ```ruby
 class TasksController < ApplicationController
-  load_and_authorize_resource :project
-  load_and_authorize_resource :task, through: :project, shallow: true
+  load_and_authorize_resource! :project
+  load_and_authorize_resource! :task, through: :project, shallow: true
 end
 ```
 
@@ -59,8 +59,8 @@ What if each project only had one task through a `has_one` association? To set u
 
 ```ruby
 class TasksController < ApplicationController
-  load_and_authorize_resource :project
-  load_and_authorize_resource :task, through: :project, singleton: true
+  load_and_authorize_resource! :project
+  load_and_authorize_resource! :task, through: :project, singleton: true
 end
 ```
 
@@ -73,7 +73,7 @@ Let's say tasks can either be assigned to a Project or an Event through a polymo
 ```ruby
 load_resource :project
 load_resource :event
-load_and_authorize_resource :task, through: [:project, :event]
+load_and_authorize_resource! :task, through: [:project, :event]
 ```
 
 Here it will check both the `@project` and `@event` variables and fetch the task through whichever one exists. Note that this is only loading the parent model, if you want to authorize the parent you will need to do it through a before_action because there is special logic involved.
@@ -143,8 +143,8 @@ and in the controller:
 
 ```ruby
 class UsersController < ApplicationController
-  load_and_authorize_resource :group
-  load_and_authorize_resource through: :group
+  load_and_authorize_resource! :group
+  load_and_authorize_resource! through: :group
 ```
 
 in ability.rb

--- a/docs/Non-RESTful-Controllers.md
+++ b/docs/Non-RESTful-Controllers.md
@@ -1,4 +1,4 @@
-You can use CanCan with controllers that do not follow the traditional show/new/edit/destroy actions, however you should not use the `load_and_authorize_resource` method since there is no resource to load. Instead you can call `authorize!` in each action separately.
+You can use CanCan with controllers that do not follow the traditional show/new/edit/destroy actions, however you should not use the `load_and_authorize_resource!` method since there is no resource to load. Instead you can call `authorize!` in each action separately.
 
 **NOTE:** This is **not** the same as having additional non-RESTful actions on a RESTful controller. See the Choosing Actions section of the [[Authorizing Controller Actions]] page for details.
 

--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -15,6 +15,7 @@ module CanCan
       def load_and_authorize_resource(*args)
         cancan_resource_class.add_before_action(self, :load_and_authorize_resource, *args)
       end
+      alias load_and_authorize_resource! load_and_authorize_resource
 
       # Sets up a before filter which loads the model resource into an instance variable.
       # For example, given an ArticlesController it will load the current article into the @article

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -33,12 +33,14 @@ module CanCan
       load_resource
       authorize_resource
     end
+    alias load_and_authorize_resource! load_and_authorize_resource
 
     def authorize_resource
       return if skip?(:authorize)
 
       @controller.authorize!(authorization_action, resource_instance || resource_class_with_parent)
     end
+    alias authorize_resource! authorize_resource
 
     def parent?
       @options.key?(:parent) ? @options[:parent] : @name && @name != name_from_controller.to_sym

--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -46,12 +46,12 @@ describe CanCan::ControllerAdditions do
 
   it 'load_and_authorize_resource with :prepend prepends the before filter' do
     expect(@controller_class).to receive(:prepend_before_action).with({})
-    @controller_class.load_and_authorize_resource foo: :bar, prepend: true
+    @controller_class.load_and_authorize_resource foo: :bar
   end
 
   it 'load_and_authorize_resource is aliased by load_and_authorize_resource!' do
-    expect(@controller_class.method(:load_and_authorize_resource!))
-      .to be(@controller_class.method(:load_and_authorize_resource))
+    expect(@controller_class).to receive(:prepend_before_action).with(:double)
+    @controller_class.load_and_authorize_resource! :double
   end
 
   it 'authorize_resource setups a before filter which passes call to ControllerResource' do

--- a/spec/cancan/controller_additions_spec.rb
+++ b/spec/cancan/controller_additions_spec.rb
@@ -49,6 +49,11 @@ describe CanCan::ControllerAdditions do
     @controller_class.load_and_authorize_resource foo: :bar, prepend: true
   end
 
+  it 'load_and_authorize_resource is aliased by load_and_authorize_resource!' do
+    expect(@controller_class.method(:load_and_authorize_resource!))
+      .to be(@controller_class.method(:load_and_authorize_resource))
+  end
+
   it 'authorize_resource setups a before filter which passes call to ControllerResource' do
     expect(cancan_resource_class = double).to receive(:authorize_resource)
     allow(CanCan::ControllerResource).to receive(:new).with(@controller, nil, foo: :bar) { cancan_resource_class }

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -340,6 +340,13 @@ describe CanCan::ControllerResource do
       resource.load_and_authorize_resource
     end
 
+    it 'calls load_resource and authorize_resource for load_and_authorize_resource! (BANG)' do
+      resource = CanCan::ControllerResource.new(controller)
+      expect(resource).to receive(:load_resource)
+      expect(resource).to receive(:authorize_resource)
+      resource.load_and_authorize_resource!
+    end
+
     it 'loads resource through the association of another parent resource using instance variable' do
       category = double(models: {})
       controller.instance_variable_set(:@category, category)

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -333,6 +333,12 @@ describe CanCan::ControllerResource do
       expect { resource.authorize_resource }.to raise_error(CanCan::AccessDenied)
     end
 
+    it 'calls authorize! for authorize_resource! (BANG)' do
+      allow(controller).to receive(:authorize!) { raise 'expectable_error'  }
+      resource = CanCan::ControllerResource.new(controller)
+      expect { resource.authorize_resource! }.to raise_error('expectable_error')
+    end
+
     it 'calls load_resource and authorize_resource for load_and_authorize_resource' do
       resource = CanCan::ControllerResource.new(controller)
       expect(resource).to receive(:load_resource)


### PR DESCRIPTION
In code reviews I find myself often asking wether usage of `load_and_authorize_resource` was safe.
Then I'll look it up in the source code and see that indeed `authorize!` is being used.

I'd like to suggest that code writers from now on per default use `load_and_authorize_resource!` 
to transport the following message to the reviewer: "this is safe, no worries".