### PR TITLE
Don't hold unnecessary references to subjects in @rules_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -684,3 +684,4 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@ayumu838]: https://github.com/ayumu838
 [@Liberatys]: https://github.com/Liberatys
 [@ghiculescu]: https://github.com/ghiculescu
+[@mtoneil]: https://github.com/mtoneil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * [#675](https://github.com/CanCanCommunity/cancancan/pull/675): Support modifying the `accessible_by` querying strategy on a per-query basis. ([@ghiculescu][])
+* [#714](https://github.com/CanCanCommunity/cancancan/pull/714): Don't hold unnecessary references to subjects in @rules_index. ([@mtoneil][])
 
 ## 3.2.1
 

--- a/lib/cancan/ability/rules.rb
+++ b/lib/cancan/ability/rules.rb
@@ -19,7 +19,7 @@ module CanCan
       end
 
       def add_rule_to_index(rule, position)
-        @rules_index ||= Hash.new
+        @rules_index ||= {}
 
         subjects = rule.subjects.compact
         subjects << :all if subjects.empty?

--- a/lib/cancan/ability/rules.rb
+++ b/lib/cancan/ability/rules.rb
@@ -19,12 +19,13 @@ module CanCan
       end
 
       def add_rule_to_index(rule, position)
-        @rules_index ||= Hash.new { |h, k| h[k] = [] }
+        @rules_index ||= Hash.new
 
         subjects = rule.subjects.compact
         subjects << :all if subjects.empty?
 
         subjects.each do |subject|
+          @rules_index[subject] ||= []
           @rules_index[subject] << position
         end
       end
@@ -48,7 +49,9 @@ module CanCan
           rules
         else
           positions = @rules_index.values_at(subject, *alternative_subjects(subject))
-          positions.flatten!.sort!
+          positions.compact!
+          positions.flatten!
+          positions.sort!
           positions.map { |i| @rules[i] }
         end
       end

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -674,6 +674,14 @@ describe CanCan::Ability do
     expect(@ability.permitted_attributes(:read, Integer)).to eq([:to_s])
   end
 
+  it 'does not retain references to subjects that do not have direct rules' do
+    @ability.can :read, String
+
+    @ability.can?(:read, 'foo')
+
+    expect(@ability.instance_variable_get(:@rules_index)).not_to have_key('foo')
+  end
+
   describe 'unauthorized message' do
     after(:each) do
       I18n.backend = nil


### PR DESCRIPTION
The @rules_index ends up holding a reference to any subject that is
authorized, by virtue of the hash having a default value of an empty
array. This in effect facilitiates a memory leak, by which objects can't
be garbage collected until the Ability instance is discarded, even
though the Ability has no use for these objects. This is especially
problematic for long-running background jobs that need to authorize many
objects (e.g. hundreds of thousands) against a single Ability instance.

By getting rid of @rule_index's default empty array value, we can allow
for better garbage collection and reduce the size of the hash. These
differences add up greatly when authorizing objects at scale.