### PR TITLE
Include LICENSE file in gem

### DIFF
--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.license     = 'MIT'
 
-  s.files       = `git ls-files lib init.rb cancancan.gemspec`.split($INPUT_RECORD_SEPARATOR)
+  s.files       = `git ls-files lib init.rb cancancan.gemspec LICENSE`.split($INPUT_RECORD_SEPARATOR)
   s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.2.0'


### PR DESCRIPTION
Make it easier for users of the gem to get to the full license text
including copyright notice.