### PR TITLE
replace the check abilities wiki link with new doc link.

### DIFF
--- a/lib/generators/cancan/ability/templates/ability.rb
+++ b/lib/generators/cancan/ability/templates/ability.rb
@@ -27,6 +27,6 @@ class Ability
     #   can :update, Article, published: true
     #
     # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
   end
 end


### PR DESCRIPTION
the wiki link in abilities.rb template is not valid any more, replace it with new md doc link.