### PR TITLE
Drop old Rubies and update RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Lint/AmbiguousBlockAssociation:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.2.0
+  TargetRubyVersion: 2.4
   Exclude:
     - 'gemfiles/**/*'
     - 'vendor/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,18 @@ Metrics/BlockLength:
     - '**/*_spec.rb'
 
 # TODO
+Metrics/ParameterLists:
+  Exclude:
+    # def initialize(message = nil, action = nil, subject = nil, conditions = nil)
+    - 'lib/cancan/exceptions.rb'
+
+# TODO
+Metrics/AbcSize:
+  Exclude:
+    # def permissions
+    - 'lib/cancan/ability.rb'
+
+# TODO
 # Offense count: 2
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist.
 # NamePrefix: is_, has_, have_
@@ -33,8 +45,20 @@ Naming/PredicateName:
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 
+# TODO
+# There are to many errors, especially phantom, with `stub_const` for `ActiveRecord::Base`
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - 'spec/**/*'
+
+# TODO
+Lint/EmptyClass:
+  Exclude:
+    - 'spec/**/*'
+
 AllCops:
   TargetRubyVersion: 2.4
+  NewCops: enable
   Exclude:
     - 'gemfiles/**/*'
     - 'vendor/**/*'

--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'cancan/version'
+require_relative 'lib/cancan/version'
 
 Gem::Specification.new do |s|
   s.name        = 'cancancan'
@@ -25,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 10.1', '>= 10.1.1'
   s.add_development_dependency 'rspec', '~> 3.2', '>= 3.2.0'
-  s.add_development_dependency 'rubocop', '~> 0.63.1'
+  s.add_development_dependency 'rubocop', '~> 1.12.0'
 end

--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files lib init.rb cancancan.gemspec`.split($INPUT_RECORD_SEPARATOR)
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_development_dependency 'appraisal', '~> 2.0', '>= 2.0.0'
   s.add_development_dependency 'bundler', '~> 2.0'

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'ability/rules.rb'
-require_relative 'ability/actions.rb'
-require_relative 'unauthorized_message_resolver.rb'
+require_relative 'ability/rules'
+require_relative 'ability/actions'
+require_relative 'unauthorized_message_resolver'
 require_relative 'ability/strong_parameter_support'
 
 module CanCan
@@ -284,7 +284,7 @@ module CanCan
     private
 
     def unauthorized_message_keys(action, subject)
-      subject = (subject.class == Class ? subject : subject.class).name.underscore unless subject.is_a? Symbol
+      subject = (subject.is_a?(Class) ? subject : subject.class).name.underscore unless subject.is_a? Symbol
       aliases = aliases_for_action(action)
       [subject, :all].product([*aliases, :manage]).map do |try_subject, try_action|
         :"#{try_action}.#{try_subject}"

--- a/lib/cancan/class_matcher.rb
+++ b/lib/cancan/class_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This class is responsible for matching classes and their subclasses as well as
 # upmatching classes to their ancestors.
 # This is used to generate sti connections

--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -25,7 +25,7 @@ module CanCan
     end
 
     def matches_non_block_conditions(subject)
-      return nested_subject_matches_conditions?(subject) if subject.class == Hash
+      return nested_subject_matches_conditions?(subject) if subject.is_a?(Hash)
       return matches_conditions_hash?(subject) unless subject_class?(subject)
 
       # Don't stop at "cannot" definitions when there are conditions.
@@ -85,7 +85,7 @@ module CanCan
     end
 
     def call_block_with_all(action, subject, *extra_args)
-      if subject.class == Class
+      if subject.is_a?(Class)
         @block.call(action, subject, nil, *extra_args)
       else
         @block.call(action, subject.class, subject, *extra_args)

--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'controller_resource_loader.rb'
+require_relative 'controller_resource_loader'
+
 module CanCan
   # Handle the load and authorization controller logic
   # so we don't clutter up all controllers with non-interface methods.

--- a/lib/cancan/controller_resource_builder.rb
+++ b/lib/cancan/controller_resource_builder.rb
@@ -19,7 +19,7 @@ module CanCan
 
     def initial_attributes
       current_ability.attributes_for(@params[:action].to_sym, resource_class).delete_if do |key, _value|
-        resource_params && resource_params.include?(key)
+        resource_params&.include?(key)
       end
     end
   end

--- a/lib/cancan/controller_resource_loader.rb
+++ b/lib/cancan/controller_resource_loader.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require_relative 'controller_resource_finder.rb'
-require_relative 'controller_resource_name_finder.rb'
-require_relative 'controller_resource_builder.rb'
-require_relative 'controller_resource_sanitizer.rb'
+require_relative 'controller_resource_finder'
+require_relative 'controller_resource_name_finder'
+require_relative 'controller_resource_builder'
+require_relative 'controller_resource_sanitizer'
+
 module CanCan
   module ControllerResourceLoader
     include CanCan::ControllerResourceNameFinder

--- a/lib/cancan/exceptions.rb
+++ b/lib/cancan/exceptions.rb
@@ -48,15 +48,16 @@ module CanCan
     attr_writer :default_message
 
     def initialize(message = nil, action = nil, subject = nil, conditions = nil)
-      @message = message
+      super message.to_s
       @action = action
       @subject = subject
       @conditions = conditions
       @default_message = I18n.t(:"unauthorized.default", default: 'You are not authorized to access this page.')
     end
 
-    def to_s
-      @message || @default_message
+    def message
+      actual = super
+      actual.empty? ? @default_message : actual
     end
 
     def inspect

--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -34,7 +34,7 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
 
   failure_message do
     resource = args[1]
-    if resource.instance_of?(Class)
+    if resource.is_a?(Class)
       "expected to be able to #{args.map(&:to_s).join(' ')}"
     else
       "expected to be able to #{args.map(&:inspect).join(' ')}"
@@ -43,7 +43,7 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
 
   failure_message_when_negated do
     resource = args[1]
-    if resource.instance_of?(Class)
+    if resource.is_a?(Class)
       "expected not to be able to #{args.map(&:to_s).join(' ')}"
     else
       "expected not to be able to #{args.map(&:inspect).join(' ')}"

--- a/lib/cancan/model_adapters/abstract_adapter.rb
+++ b/lib/cancan/model_adapters/abstract_adapter.rb
@@ -4,6 +4,7 @@ module CanCan
   module ModelAdapters
     class AbstractAdapter
       def self.inherited(subclass)
+        super
         @subclasses ||= []
         @subclasses.insert(0, subclass)
       end

--- a/lib/cancan/model_adapters/conditions_normalizer.rb
+++ b/lib/cancan/model_adapters/conditions_normalizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # this class is responsible of normalizing the hash of conditions
 # by exploding has_many through associations
 # when a condition is defined with an has_many thorugh association this is exploded in all its parts

--- a/lib/cancan/model_adapters/sti_normalizer.rb
+++ b/lib/cancan/model_adapters/sti_normalizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # this class is responsible for detecting sti classes and creating new rules for the
 # relevant subclasses, using the inheritance_column as a merger
 module CanCan

--- a/lib/cancan/relevant.rb
+++ b/lib/cancan/relevant.rb
@@ -4,7 +4,7 @@ module CanCan
   module Relevant
     # Matches both the action, subject, and attribute, not necessarily the conditions
     def relevant?(action, subject)
-      subject = subject.values.first if subject.class == Hash
+      subject = subject.values.first if subject.instance_of?(Hash)
       @match_all || (matches_action?(action) && matches_subject?(subject))
     end
 

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'conditions_matcher.rb'
-require_relative 'class_matcher.rb'
-require_relative 'relevant.rb'
+require_relative 'conditions_matcher'
+require_relative 'class_matcher'
+require_relative 'relevant'
 
 module CanCan
   # This class is used internally and should only be called through Ability.
@@ -12,8 +12,10 @@ module CanCan
     include ConditionsMatcher
     include Relevant
     include ParameterValidators
-    attr_reader :base_behavior, :subjects, :actions, :conditions, :attributes, :block
-    attr_writer :expanded_actions, :conditions
+
+    attr_reader :base_behavior, :subjects, :actions, :attributes, :block
+    attr_writer :expanded_actions
+    attr_accessor :conditions
 
     # The first argument when initializing is the base_behavior which is a true/false
     # value. True for "can" and false for "cannot". The next two arguments are the action
@@ -45,7 +47,7 @@ module CanCan
         repr += ", #{@conditions.inspect}"
       end
 
-      repr + '>'
+      "#{repr}>"
     end
 
     def can_rule?

--- a/lib/cancan/rules_compressor.rb
+++ b/lib/cancan/rules_compressor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'conditions_matcher.rb'
+require_relative 'conditions_matcher'
+
 module CanCan
   class RulesCompressor
     attr_reader :initial_rules, :rules_collapsed

--- a/lib/cancan/unauthorized_message_resolver.rb
+++ b/lib/cancan/unauthorized_message_resolver.rb
@@ -13,7 +13,7 @@ module CanCan
     end
 
     def translate_subject(subject)
-      klass = (subject.class == Class ? subject : subject.class)
+      klass = (subject.is_a?(Class) ? subject : subject.class)
       if klass.respond_to?(:model_name)
         klass.model_name.human
       else

--- a/lib/cancan/version.rb
+++ b/lib/cancan/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanCan
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.3.0'
 end

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -383,9 +383,11 @@ describe CanCan::Ability do
   it 'allows to check ability for Module' do
     module B
     end
+
     class A
       include B
     end
+
     @ability.can :read, B
     expect(@ability.can?(:read, A)).to be(true)
     expect(@ability.can?(:read, A.new)).to be(true)
@@ -394,9 +396,11 @@ describe CanCan::Ability do
   it 'passes nil to a block for ability on Module when no instance is passed' do
     module B
     end
+
     class A
       include B
     end
+
     @ability.can :read, B do |sym|
       expect(sym).to be_nil
       true
@@ -701,10 +705,10 @@ describe CanCan::Ability do
 
       I18n.backend.store_translations :en,
                                       activemodel: { models: { account: 'english name' } },
-                                      unauthorized: { update: { all: '%{subject}' } }
+                                      unauthorized: { update: { all: '%<subject>s' } }
       I18n.backend.store_translations :ja,
                                       activemodel: { models: { account: 'japanese name' } },
-                                      unauthorized: { update: { all: '%{subject}' } }
+                                      unauthorized: { update: { all: '%<subject>s' } }
 
       I18n.with_locale(:en) do
         expect(@ability.unauthorized_message(:update, Account)).to eq('english name')
@@ -722,10 +726,10 @@ describe CanCan::Ability do
 
       I18n.backend.store_translations :en,
                                       actions: { update: 'english name' },
-                                      unauthorized: { update: { all: '%{action}' } }
+                                      unauthorized: { update: { all: '%<action>s' } }
       I18n.backend.store_translations :ja,
                                       actions: { update: 'japanese name' },
-                                      unauthorized: { update: { all: '%{action}' } }
+                                      unauthorized: { update: { all: '%<action>s' } }
 
       I18n.with_locale(:en) do
         expect(@ability.unauthorized_message(:update, Account)).to eq('english name')

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -534,7 +534,9 @@ describe CanCan::ControllerResource do
   context 'when @name passed as symbol' do
     it 'returns namespaced #resource_class' do
       module Admin; end
+
       class Admin::Dashboard; end
+
       params[:controller] = 'admin/dashboard'
       resource = CanCan::ControllerResource.new(controller, :dashboard)
 

--- a/spec/cancan/model_adapters/accessible_by_has_many_through_spec.rb
+++ b/spec/cancan/model_adapters/accessible_by_has_many_through_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 # integration tests for latest ActiveRecord version.

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -490,15 +490,13 @@ describe CanCan::ModelAdapters::ActiveRecordAdapter do
       expect(Comment.accessible_by(@ability).order('articles.name')).to match_array([comment2, comment1])
 
       # works with the explicit join in AR 5.2+ and AR 4.2
-      if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0')
+      if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.2.0') ||
+         CanCan::ModelAdapters::ActiveRecordAdapter.version_lower?('5.0.0')
         expect(Comment.accessible_by(@ability).joins(:article).order('articles.name'))
           .to match_array([comment2, comment1])
-      elsif CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
+      else
         expect { Comment.accessible_by(@ability).joins(:article).order('articles.name').to_a }
           .to raise_error(ActiveRecord::StatementInvalid)
-      else
-        expect(Comment.accessible_by(@ability).joins(:article).order('articles.name'))
-          .to match_array([comment2, comment1])
       end
     end
 

--- a/spec/cancan/model_adapters/conditions_extractor_spec.rb
+++ b/spec/cancan/model_adapters/conditions_extractor_spec.rb
@@ -121,18 +121,28 @@ RSpec.describe CanCan::ModelAdapters::ConditionsExtractor do
     end
 
     it 'converts very complex nested sets' do
-      original_conditions = { user: { id: 1 },
-                              mentioned_users: { name: 'a name',
-                                                 mentioned_articles: { id: 2 },
-                                                 articles: { user: { name: 'deep' },
-                                                             mentioned_users: { name: 'd2' } } } }
+      original_conditions = {
+        user: { id: 1 },
+        mentioned_users: {
+          name: 'a name',
+          mentioned_articles: { id: 2 },
+          articles: {
+            user: { name: 'deep' },
+            mentioned_users: { name: 'd2' }
+          }
+        }
+      }
 
       conditions = described_class.new(Article).tableize_conditions(original_conditions)
-      expect(conditions).to eq(users: { id: 1 },
-                               mentioned_articles_users: { id: 2 },
-                               mentioned_users_articles: { name: 'a name' },
-                               users_articles: { name: 'deep' },
-                               mentioned_users_articles_2: { name: 'd2' })
+      # rubocop:disable Naming/VariableNumber
+      expect(conditions).to eq(
+        users: { id: 1 },
+        mentioned_articles_users: { id: 2 },
+        mentioned_users_articles: { name: 'a name' },
+        users_articles: { name: 'deep' },
+        mentioned_users_articles_2: { name: 'd2' }
+      )
+      # rubocop:enable Naming/VariableNumber
     end
 
     it 'converts complex nested sets with duplicates' do

--- a/spec/cancan/model_adapters/conditions_normalizer_spec.rb
+++ b/spec/cancan/model_adapters/conditions_normalizer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe CanCan::ModelAdapters::ConditionsNormalizer do
@@ -5,15 +7,13 @@ RSpec.describe CanCan::ModelAdapters::ConditionsNormalizer do
     connect_db
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Schema.define do
-      create_table(:articles) do |t|
-      end
+      create_table(:articles)
 
       create_table(:users) do |t|
         t.string :name
       end
 
-      create_table(:comments) do |t|
-      end
+      create_table(:comments)
 
       create_table(:spread_comments) do |t|
         t.integer :article_id
@@ -30,8 +30,7 @@ RSpec.describe CanCan::ModelAdapters::ConditionsNormalizer do
         t.integer :blob_id
       end
 
-      create_table(:blob) do |t|
-      end
+      create_table(:blob)
     end
 
     class Article < ActiveRecord::Base

--- a/spec/cancan/model_adapters/has_and_belongs_to_many_spec.rb
+++ b/spec/cancan/model_adapters/has_and_belongs_to_many_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe CanCan::ModelAdapters::ActiveRecord5Adapter do

--- a/spec/cancan/rule_compressor_spec.rb
+++ b/spec/cancan/rule_compressor_spec.rb
@@ -4,8 +4,7 @@ require 'spec_helper'
 
 describe CanCan::RulesCompressor do
   before do
-    class Blog
-    end
+    class Blog; end
   end
 
   def can(action, subject, args = nil)

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'changelog' do
     describe 'link to related issue' do
       let(:issues) do
         entries.map do |entry|
-          entry.match(/\[(?<number>[#\d]+)\]\((?<url>[^\)]+)\)/)
+          entry.match(/\[(?<number>[#\d]+)\]\((?<url>[^)]+)\)/)
         end.compact
       end
 
@@ -83,7 +83,7 @@ RSpec.describe 'changelog' do
           entry
             .gsub(/`[^`]+`/, '``')
             .sub(/^\*\s*(?:\[.+?\):\s*)?/, '')
-            .sub(/\s*\([^\)]+\)$/, '')
+            .sub(/\s*\([^)]+\)$/, '')
         end
       end
 
@@ -94,7 +94,7 @@ RSpec.describe 'changelog' do
       end
 
       it 'ends with a punctuation' do
-        expect(bodies).to all(match(/[\.\!]$/))
+        expect(bodies).to all(match(/[.!]$/))
       end
     end
   end

--- a/spec/matchers.rb
+++ b/spec/matchers.rb
@@ -2,7 +2,7 @@
 
 RSpec::Matchers.define :orderlessly_match do |original_string|
   match do |given_string|
-    original_string.split('').sort == given_string.split('').sort
+    original_string.chars.sort == given_string.chars.sort
   end
 
   failure_message do |given_string|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,8 +12,7 @@ require 'cancan/matchers'
 I18n.enforce_available_locales = false if defined?(I18n) && I18n.respond_to?('enforce_available_locales=')
 
 # Add support to load paths
-$LOAD_PATH.unshift File.expand_path('support', __dir__)
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.filter_run focus: true


### PR DESCRIPTION
Fix (and disable) new offenses.

Ruby 2.3 EOL was 31 months ago. We even don't test with them.
