### PR TITLE
Debug exists subquery

### DIFF
--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.1', '>= 10.1.1'
   s.add_development_dependency 'rspec', '~> 3.2', '>= 3.2.0'
   s.add_development_dependency 'rubocop', '~> 0.63.1'
+  s.add_development_dependency 'byebug', '~> 9.0', '>= 9.0.0'
 end

--- a/lib/cancan.rb
+++ b/lib/cancan.rb
@@ -24,4 +24,5 @@ if defined? ActiveRecord
   require 'cancan/model_adapters/strategies/base'
   require 'cancan/model_adapters/strategies/left_join'
   require 'cancan/model_adapters/strategies/subquery'
+  require 'cancan/model_adapters/strategies/exists_subquery'
 end

--- a/lib/cancan/config.rb
+++ b/lib/cancan/config.rb
@@ -3,8 +3,14 @@
 module CanCan
   def self.valid_accessible_by_strategies
     strategies = [:left_join]
-    strategies << :subquery unless does_not_support_subquery_strategy?
+    unless does_not_support_subquery_strategy?
+      strategies.push(*subquery_strategies)
+    end
     strategies
+  end
+
+  def self.subquery_strategies
+    [:subquery, :exists_subquery]
   end
 
   # Determines how CanCan should build queries when calling accessible_by,
@@ -40,8 +46,8 @@ module CanCan
   def self.accessible_by_strategy=(value)
     validate_accessible_by_strategy!(value)
 
-    if value == :subquery && does_not_support_subquery_strategy?
-      raise ArgumentError, 'accessible_by_strategy = :subquery requires ActiveRecord 5 or newer'
+    if subquery_strategies.include?(value) && does_not_support_subquery_strategy?
+      raise ArgumentError, "accessible_by_strategy = #{value} requires ActiveRecord 5 or newer"
     end
 
     @accessible_by_strategy = value

--- a/lib/cancan/model_adapters/strategies/exists_subquery.rb
+++ b/lib/cancan/model_adapters/strategies/exists_subquery.rb
@@ -1,0 +1,22 @@
+module CanCan
+  module ModelAdapters
+    class Strategies
+      class ExistsSubquery < Base
+        def execute!
+          model_class.where(joined_alias_exists_subquery_inner_query.arel.exists)
+        end
+
+        def joined_alias_exists_subquery_inner_query
+          model_class
+            .select('1')
+            .left_joins(joins)
+            .where(*where_conditions)
+            .where(
+              "#{quoted_table_name}.#{quoted_primary_key} = " \
+              "#{quoted_aliased_table_name}.#{quoted_primary_key}"
+            )
+        end
+      end
+    end
+  end
+end

--- a/lib/cancan/model_adapters/strategies/subquery.rb
+++ b/lib/cancan/model_adapters/strategies/subquery.rb
@@ -3,13 +3,7 @@ module CanCan
     class Strategies
       class Subquery < Base
         def execute!
-          build_joins_relation_subquery(where_conditions)
-        end
-
-        def build_joins_relation_subquery(where_conditions)
-          inner = model_class.unscoped do
-            model_class.left_joins(joins).where(*where_conditions)
-          end
+          inner = model_class.unscoped { model_class.left_joins(joins).where(*where_conditions) }
           model_class.where(model_class.primary_key => inner)
         end
       end

--- a/spec/cancan/model_adapters/accessible_by_has_many_through_spec.rb
+++ b/spec/cancan/model_adapters/accessible_by_has_many_through_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe CanCan::ModelAdapters::ActiveRecord5Adapter do
       if CanCan::ModelAdapters::ActiveRecordAdapter.version_greater_or_equal?('5.0.0')
         describe 'selecting custom columns' do
           it 'extracts custom columns correctly' do
-            posts = Post.accessible_by(ability).where(published: true).select('title as mytitle')
+            posts = Post.where(title: 'a').accessible_by(ability).where(published: true).select('title as mytitle')
+            puts posts.to_sql
             expect(posts[0].mytitle).to eq 'post1'
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'bundler/setup'
 
 Bundler.require
 
+require 'byebug'
 require 'matchers'
 require 'cancan/matchers'
 


### PR DESCRIPTION
This PR is a draft to debug the behavior of an exists subquery implemented in #691 

Run the relevant test with:

```
DB='sqlite' bundle exec appraisal activerecord_6.0.0 rspec spec/cancan/model_adapters/accessible_by_has_many_through_spec.rb[1:3:2:1]
```

My debugging started because I wanted to understand why we need this JOIN: https://github.com/CanCanCommunity/cancancan/pull/691/files#diff-1ac9b926205ddc47154cac149a2a53d61c308efc15b59bfdea7b13ec6565fff1R63-R64

Apparently is because otherwise it is basically impossible to alias the tables in the inner exists subquery.