### PR TITLE
verify if activerecord is defined

### DIFF
--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -70,7 +70,7 @@ module CanCan
     end
 
     def with_scope?
-      @conditions.is_a?(ActiveRecord::Relation)
+      defined?(ActiveRecord) && @conditions.is_a?(ActiveRecord::Relation)
     end
 
     def associations_hash(conditions = @conditions)


### PR DESCRIPTION
Fixing problem on rules when the app isn't using ActiveRecord.
There are some recent issues reporting it, for example: https://github.com/CanCanCommunity/cancancan/issues/742.

I think this pr can solve the exception. 