### PR TITLE
Add support for non-hash conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 
+* [#772](https://github.com/CanCanCommunity/cancancan/pull/772): Support non-hash conditions in ability definitions. ([@Juleffel][])
 * [#773](https://github.com/CanCanCommunity/cancancan/pull/773): Drop support for ruby 2.4 and 2.5. ([@coorasse][])
 
 ## 3.3.0
@@ -693,3 +694,4 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@Liberatys]: https://github.com/Liberatys
 [@ghiculescu]: https://github.com/ghiculescu
 [@mtoneil]: https://github.com/mtoneil
+[@Juleffel]: https://github.com/Juleffel

--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -42,7 +42,7 @@ module CanCan
     # override_matching_for_conditions?(subject, conditions) and
     # matches_conditions_hash?(subject, conditions)
     def matches_conditions_hash?(subject, conditions = @conditions)
-      return true if conditions.empty?
+      return true if conditions.is_a?(Hash) && conditions.empty?
 
       adapter = model_adapter(subject)
 
@@ -54,6 +54,16 @@ module CanCan
     end
 
     def matches_all_conditions?(adapter, conditions, subject)
+      if conditions.is_a?(Hash)
+        matches_hash_conditions(adapter, conditions, subject)
+      elsif conditions.respond_to?(:include?)
+        conditions.include?(subject)
+      else
+        subject == conditions
+      end
+    end
+
+    def matches_hash_conditions(adapter, conditions, subject)
       conditions.all? do |name, value|
         if adapter.override_condition_matching?(subject, name, value)
           adapter.matches_condition?(subject, name, value)

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -829,4 +829,38 @@ describe CanCan::Ability do
       expect(@ability.send(:rules).size).to eq(0)
     end
   end
+
+  describe 'when #can? is used with a Hash (nested resources)' do
+    it 'is unauthorized with no rules' do
+      expect(@ability.can?(:read, 1 => Symbol)).to be(false)
+    end
+
+    it 'is authorized when the child is authorized' do
+      @ability.can :read, Symbol
+      expect(@ability.can?(:read, 1 => Symbol)).to be(true)
+    end
+
+    it 'is authorized when the condition doesn\'t concern the parent' do
+      @ability.can :read, Symbol, whatever: true
+      expect(@ability.can?(:read, 1 => Symbol)).to be(true)
+    end
+
+    it 'verifies the parent against an equality condition' do
+      @ability.can :read, Symbol, integer: 1
+      expect(@ability.can?(:read, 1 => Symbol)).to be(true)
+      expect(@ability.can?(:read, 2 => Symbol)).to be(false)
+    end
+
+    it 'verifies the parent against an array condition' do
+      @ability.can :read, Symbol, integer: [0, 1]
+      expect(@ability.can?(:read, 1 => Symbol)).to be(true)
+      expect(@ability.can?(:read, 2 => Symbol)).to be(false)
+    end
+
+    it 'verifies the parent against a hash condition' do
+      @ability.can :read, Symbol, integer: { to_i: 1 }
+      expect(@ability.can?(:read, 1 => Symbol)).to be(true)
+      expect(@ability.can?(:read, 2 => Symbol)).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Extracted from the work of @Juleffel on #767, it isolates the fix for non-hash conditions. It also fixes rubocop complains