### PR TITLE
Fix table alias generation mismatch in ConditionsExtractor

### DIFF
--- a/lib/cancan/model_adapters/conditions_extractor.rb
+++ b/lib/cancan/model_adapters/conditions_extractor.rb
@@ -51,11 +51,12 @@ module CanCan
         table_alias = model_class.reflect_on_association(relation_name).table_name.to_sym
 
         if already_used?(table_alias, relation_name, path_to_key)
-          table_alias = "#{relation_name.to_s.pluralize}_#{model_class.table_name}".to_sym
+          table_alias_prefix = "#{relation_name.to_s.pluralize}_#{model_class.table_name}".to_sym
+          table_alias = table_alias_prefix
 
           index = 1
           while already_used?(table_alias, relation_name, path_to_key)
-            table_alias = "#{table_alias}_#{index += 1}".to_sym
+            table_alias = "#{table_alias_prefix}_#{index += 1}".to_sym
           end
         end
         add_to_cache(table_alias, relation_name, path_to_key)

--- a/spec/cancan/model_adapters/conditions_extractor_spec.rb
+++ b/spec/cancan/model_adapters/conditions_extractor_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe CanCan::ModelAdapters::ConditionsExtractor do
         t.integer :sender_id
         t.integer :receiver_id
         t.integer :supervisor_id
+        t.integer :approver_id
       end
     end
 
@@ -86,6 +87,7 @@ RSpec.describe CanCan::ModelAdapters::ConditionsExtractor do
       belongs_to :sender, class_name: 'User', foreign_key: :sender_id
       belongs_to :receiver, class_name: 'User', foreign_key: :receiver_id
       belongs_to :supervisor, class_name: 'User', foreign_key: :supervisor_id
+      belongs_to :approver, class_name: 'User', foreign_key: :approver_id
     end
   end
 
@@ -144,6 +146,24 @@ RSpec.describe CanCan::ModelAdapters::ConditionsExtractor do
                                articles: { id: 'article1' },
                                receivers_transactions: { id: 'receiver' },
                                articles_users: { id: 'article2' })
+    end
+
+    it 'converts multiple references of same table with incrementing indexes' do
+      original_conditions = [
+        { sender: { mentions: { id: '1' } } },
+        { receiver: { mentions: { id: '1' } } },
+        { supervisor: { mentions: { id: '1' } } },
+        { approver: { mentions: { id: '1' } } }
+      ]
+
+      extractor = described_class.new(Transaction)
+      conditions = original_conditions.map do |condition|
+        extractor.tableize_conditions(condition).dup
+      end
+      expect(conditions).to eq([{ legacy_mentions: { id: '1' } },
+                                { mentions_users: { id: '1' } },
+                                { mentions_users_2: { id: '1' } },
+                                { mentions_users_3: { id: '1' } }])
     end
   end
 end


### PR DESCRIPTION
Previously in the provided test case, the aliases would have been generated as:
- `mentions_users`
- `mentions_users_2`
- `mentions_users_2_3`

This was causing issues where the join would be aliases as `mentions_users_3`, however the where statement would be querying a column off `mentions_users_2_3` when using `accessible_by`

After this change, the aliases are generated as:
- `mentions_users`
- `mentions_users_2`
- `mentions_users_3`

This allows table names to correctly match up and the query to succeed.

---

Happy to provide a deeper example if needed, however I would need to anonymise the table names