### PR TITLE
Delegate controller action to check against defined resource

### DIFF
--- a/lib/cancan/controller_resource_loader.rb
+++ b/lib/cancan/controller_resource_loader.rb
@@ -92,7 +92,7 @@ module CanCan
     end
 
     def parent_authorization_action
-      @options[:parent_action] || :show
+      @options[:parent_action] || @params[:action].to_sym
     end
 
     def authorization_action

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'pry'
 
 describe CanCan::ControllerResource do
   let(:ability) { Ability.new(nil) }
@@ -52,12 +53,13 @@ describe CanCan::ControllerResource do
       expect(controller.instance_variable_get(:@model)).to eq(:some_model)
     end
 
-    it 'only authorizes :show action on parent resource' do
+    it 'delegate controller action on parent resource' do
       model = Model.new
       allow(Model).to receive(:find).with('123') { model }
 
       params[:model_id] = 123
-      allow(controller).to receive(:authorize!).with(:show, model) { raise CanCan::AccessDenied }
+      action = controller.params[:action].to_sym
+      allow(controller).to receive(:authorize!).with(action, model) { raise CanCan::AccessDenied }
       resource = CanCan::ControllerResource.new(controller, :model, parent: true)
       expect { resource.load_and_authorize_resource }.to raise_error(CanCan::AccessDenied)
     end
@@ -229,7 +231,7 @@ describe CanCan::ControllerResource do
 
     it 'authorizes parent resource in collection action' do
       controller.instance_variable_set(:@category, :some_category)
-      allow(controller).to receive(:authorize!).with(:show, :some_category) { raise CanCan::AccessDenied }
+      allow(controller).to receive(:authorize!).with(:index, :some_category) { raise CanCan::AccessDenied }
 
       resource = CanCan::ControllerResource.new(controller, :category, parent: true)
       expect { resource.authorize_resource }.to raise_error(CanCan::AccessDenied)


### PR DESCRIPTION
Fix for issue [#791](https://github.com/CanCanCommunity/cancancan/issues/791)

Avoid running permissions against a hard-coded action, instead, delegate the permission against the controller action.