### PR TITLE
allow to use action specific sanitization method with model name

### DIFF
--- a/lib/cancan/controller_resource_sanitizer.rb
+++ b/lib/cancan/controller_resource_sanitizer.rb
@@ -16,7 +16,12 @@ module CanCan
     end
 
     def params_methods
-      methods = ["#{@params[:action]}_params".to_sym, "#{name}_params".to_sym, :resource_params]
+      methods = [
+        "#{@params[:action]}_params".to_sym, 
+        "#{name}_params".to_sym, 
+        :resource_params,
+        "#{@params[:action]}_#{name}_params".to_sym, 
+      ]
       methods.unshift(@options[:param_method]) if @options[:param_method].present?
       methods
     end

--- a/spec/cancan/controller_resource_spec.rb
+++ b/spec/cancan/controller_resource_spec.rb
@@ -186,6 +186,12 @@ describe CanCan::ControllerResource do
         resource = CanCan::ControllerResource.new(controller)
         expect(resource.send('resource_params')).to eq(resource: 'params')
       end
+
+      it 'use the <action>_<model_name>_params method for sanitizing input if no other method is found' do
+        allow(controller).to receive(:create_model_params).and_return(model: 'params')
+        resource = CanCan::ControllerResource.new(controller)
+        expect(resource.send('resource_params')).to eq(model: 'params')
+      end
     end
   end
 


### PR DESCRIPTION
Its a common pattern to name strong parameters method with the model's name like `patients_params`
But it is also common splitting sanitization methods for `:create` and `:update` actions, and it can follow the same naming style too like `:create_patients_params` or `update_patients_params` as the other style `create_params` that currently is supported by `CanCanCan`.

It PR adds support to detect and use as the latest choice the named `<action>_<model_name>_params` method for sanitization.