### PR TITLE
Handle Rspec negated be_able_to for actions list

### DIFF
--- a/lib/cancan/matchers.rb
+++ b/lib/cancan/matchers.rb
@@ -22,6 +22,19 @@ Kernel.const_get(rspec_module)::Matchers.define :be_able_to do |*args|
       ability.can?(*args)
     end
   end
+  
+  match_when_negated do |ability|
+    actions = args.first
+    if actions.is_a? Array
+      if actions.empty?
+        false
+      else
+        actions.all? { |action| ability.cannot?(action, *args[1..-1]) }
+      end
+    else
+      ability.can?(*args)
+    end
+  end
 
   # Check that RSpec is < 2.99
   if !respond_to?(:failure_message) && respond_to?(:failure_message_for_should)


### PR DESCRIPTION
Currently, the rspec matcher handles list of actions correctly for ```to be_able_to``` case and returns successfully when the user is allowed to perform all the specified actions.

But, it doesn't work correctly for a list of actions for the negated cases.

```ruby
# Ability
can [:read, :create, :update], Account

it { is_expected.to be_able_to([:read, :create], Account.new) }  # Passes when user is allowed to perform both actions (read, create)

it { is_expected.not_to be_able_to([:destroy, :read], Account.new) }  # Passes even though user is allowed to read
```

The underlying issue is this line
```ruby
actions.all? { |action| ability.can?(action, *args[1..-1]) }
```
It will return false when we have some true values and even one false value.

PR fixes the issue by making use of => https://relishapp.com/rspec/rspec-expectations/docs/custom-matchers/define-a-custom-matcher#matcher-with-separate-logic-for-expect().to-and-expect().not-to