### PR TITLE
add support for polymorphic associations in active record

### DIFF
--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -39,10 +39,12 @@ module CanCan
     def nested_subject_matches_conditions?(subject_hash)
       parent, child = subject_hash.first
 
-      matches_base_parent_conditions = matches_conditions_hash?(parent,
-                                                                @conditions[parent.class.name.downcase.to_sym] || {})
-
       adapter = model_adapter(parent)
+
+      parent_condition_name = adapter.parent_condition_name(parent, child)
+
+      matches_base_parent_conditions = matches_conditions_hash?(parent,
+                                                                @conditions[parent_condition_name] || {})
 
       matches_base_parent_conditions &&
         (!adapter.override_nested_subject_conditions_matching?(parent, child, @conditions) ||

--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -73,7 +73,6 @@ module CanCan
       elsif conditions.respond_to?(:include?)
         conditions.include?(subject)
       else
-        puts "does #{subject} match #{conditions}?"
         subject == conditions
       end
     end

--- a/lib/cancan/model_adapters/abstract_adapter.rb
+++ b/lib/cancan/model_adapters/abstract_adapter.rb
@@ -35,6 +35,11 @@ module CanCan
         raise NotImplemented, 'This model adapter does not support matching on a conditions hash.'
       end
 
+      # Override if parent condition could be under a different key in conditions
+      def self.parent_condition_name(parent, _child)
+        parent.class.name.downcase.to_sym
+      end
+
       # Used above override_conditions_hash_matching to determine if this model adapter will override the
       # matching behavior for nested subject.
       # If this returns true then nested_subject_matches_conditions? will be called.


### PR DESCRIPTION
This PR attempts to add support for polymorphic associations in Active Record. It addresses this issue: https://github.com/CanCanCommunity/cancancan/issues/793

The solution works for the most part but there are some difficulties with making it work correctly for using the association name instead of the association id.

I am not very familiar with the CanCan code base so I was hoping to get some help finalizing this and ensuring backwards compatibility.

If anyone could clone this and run the tests, you will see some failures highlighting where things aren't quite working as needed. I have attempted to make some changes to address them without breaking compatibility, but I can't afford to go too deep into this at the time so I am putting it up in hopes someone can take it across the finish line (or tell me how to go about it).

UPDATE: I had a moment of inspiration and found a way to get tests passing. I am still not convinced this is the most elegant or best solution, but tests pass and it allows me to define abilities on polymorphic associations.

Feedback welcome!

Thanks!