### PR TITLE
Renames method name in ConditionsMatcher

### DIFF
--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -67,7 +67,7 @@ module CanCan
 
     def matches_all_conditions?(adapter, subject, conditions)
       if conditions.is_a?(Hash)
-        matches_hash_conditions(adapter, subject, conditions)
+        matches_hash_conditions?(adapter, subject, conditions)
       elsif conditions.respond_to?(:include?)
         conditions.include?(subject)
       else
@@ -76,7 +76,7 @@ module CanCan
       end
     end
 
-    def matches_hash_conditions(adapter, subject, conditions)
+    def matches_hash_conditions?(adapter, subject, conditions)
       conditions.all? do |name, value|
         if adapter.override_condition_matching?(subject, name, value)
           adapter.matches_condition?(subject, name, value)


### PR DESCRIPTION
Renames `ConditionsMatcher#matches_hash_conditions` to `matches_hash_conditions?` to better communicate that it returns a boolean, like the other `matches_xx?` methods.