### PR TITLE
Remove puts statement

### DIFF
--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -71,7 +71,6 @@ module CanCan
       elsif conditions.respond_to?(:include?)
         conditions.include?(subject)
       else
-        puts "does #{subject} match #{conditions}?"
         subject == conditions
       end
     end


### PR DESCRIPTION
This removes a `puts` statement introduced in dcb429aef63910130811c7f212772b7fa918a926. I assume this wasn't left in intentionally?

It litters the output a bit when running tests or the app itself.