### PR TITLE
Add documentation for id_param to authorize_resource

### DIFF
--- a/lib/cancan/controller_additions.rb
+++ b/lib/cancan/controller_additions.rb
@@ -171,6 +171,11 @@ module CanCan
       # [:+instance_name+]
       #   The name of the instance variable for this resource.
       #
+      # [:+id_param+]
+      #   Find using a param key other than :id. For example:
+      #
+      #     load_resource :id_param => :url # will use find(params[:url])
+      #
       # [:+through+]
       #   Authorize conditions on this parent resource when instance isn't available.
       #


### PR DESCRIPTION
Currently the id_param is not documented for authorize_resource. This commit adds the documentation.