### PR TITLE
Extend member_action? by checking for instance_name id

### DIFF
--- a/lib/cancan/controller_resource.rb
+++ b/lib/cancan/controller_resource.rb
@@ -80,7 +80,7 @@ module CanCan
 
     def member_action?
       new_actions.include?(@params[:action].to_sym) || @options[:singleton] ||
-        ((@params[:id] || @params[@options[:id_param]]) &&
+        ((@params[:id] || @params["#{instance_name}_id"] || @params[@options[:id_param]]) &&
           !collection_actions.include?(@params[:action].to_sym))
     end
 

--- a/lib/cancan/controller_resource_finder.rb
+++ b/lib/cancan/controller_resource_finder.rb
@@ -28,7 +28,8 @@ module CanCan
     end
 
     def id_param
-      @params[id_param_key].to_s if @params[id_param_key].present?
+      return @params[id_param_key].to_s if @params[id_param_key].present?
+      return @params["#{instance_name}_id"].to_s if @params["#{instance_name}_id"].present?
     end
 
     def id_param_key


### PR DESCRIPTION
Currently only :id and :id_param are checked for member_action?. I think it makes sense to extend it by instance_name id.

Given the following url

/authors/1/books/1

the rails route might look like 

/authors/:id/books/:book_id or /authors/:author_id/books/:book_id

In these cases the member_action? will return false for either one or both controllers, since it won't find the :id param. This results in not loading the instance for actions like show/edit when using _authorize_resource_. The solution here is to explicity set the id_param option. But from my point of view, this id naming scheme is quite common and should be considered when checking the id param.

This PR adds an id check for instance_name + _id, which would fullfil most of these cases.
