### PR TITLE
In permitted_attributes, switch from database column detection to Rails attributes detection. Addresses #838

### DIFF
--- a/lib/cancan/ability/strong_parameter_support.rb
+++ b/lib/cancan/ability/strong_parameter_support.rb
@@ -31,7 +31,7 @@ module CanCan
         klass = subject_class?(subject) ? subject : subject.class
         # empty attributes is an 'all'
         if rule.attributes.empty? && klass < ActiveRecord::Base
-          klass.column_names.map(&:to_sym) - Array(klass.primary_key)
+          klass.attribute_names.map(&:to_sym) - Array(klass.primary_key)
         else
           rule.attributes
         end

--- a/lib/cancan/ability/strong_parameter_support.rb
+++ b/lib/cancan/ability/strong_parameter_support.rb
@@ -31,7 +31,7 @@ module CanCan
         klass = subject_class?(subject) ? subject : subject.class
         # empty attributes is an 'all'
         if rule.attributes.empty? && klass < ActiveRecord::Base
-          klass.attribute_names.map(&:to_sym) - Array(klass.primary_key)
+          klass.column_names.map(&:to_sym) - Array(klass.primary_key)
         else
           rule.attributes
         end

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -17,6 +17,7 @@ describe CanCan::Ability do
 
     unless defined?(NamedUser)
       class NamedUser < ActiveRecord::Base
+        attribute :role, :string # Virtual only
       end
     end
   end
@@ -668,7 +669,7 @@ describe CanCan::Ability do
     @ability.can :read, NamedUser
     @ability.can :read, Array, :special
     @ability.can :action, :subject, :attribute
-    expect(@ability.permitted_attributes(:read, NamedUser)).to eq(%i[id first_name last_name])
+    expect(@ability.permitted_attributes(:read, NamedUser)).to eq(%i[id first_name last_name role])
     expect(@ability.permitted_attributes(:read, Array)).to eq([:special])
     expect(@ability.permitted_attributes(:action, :subject)).to eq([:attribute])
   end

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -5,6 +5,20 @@ require 'spec_helper'
 describe CanCan::Ability do
   before(:each) do
     (@ability = double).extend(CanCan::Ability)
+
+    connect_db
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Schema.define do
+      create_table(:named_users) do |t|
+        t.string :first_name
+        t.string :last_name
+      end
+    end
+
+    unless defined?(NamedUser)
+      class NamedUser < ActiveRecord::Base
+      end
+    end
   end
 
   it 'is able to :read anything' do
@@ -651,13 +665,10 @@ describe CanCan::Ability do
   end
 
   it 'returns an array of permitted attributes for a given action and subject' do
-    user_class = Class.new(ActiveRecord::Base)
-    allow(user_class).to receive(:column_names).and_return(%w[first_name last_name])
-    allow(user_class).to receive(:primary_key).and_return('id')
-    @ability.can :read, user_class
+    @ability.can :read, NamedUser
     @ability.can :read, Array, :special
     @ability.can :action, :subject, :attribute
-    expect(@ability.permitted_attributes(:read, user_class)).to eq(%i[first_name last_name])
+    expect(@ability.permitted_attributes(:read, NamedUser)).to eq(%i[id first_name last_name])
     expect(@ability.permitted_attributes(:read, Array)).to eq([:special])
     expect(@ability.permitted_attributes(:action, :subject)).to eq([:attribute])
   end


### PR DESCRIPTION
This pull request addresses #838 and makes Cancancan "see" attributes that are not backed by the database. It enables code like the following:

```ruby
class Foo < ApplicationRecord
  attribute :bar
end
```

With this pull request, cancancan's `permitted_attributes` will "see" and include `:bar` even when there is no corresponding column in the database.

Reasonning why this is a good idea: When implementing a form and checking for per-attribute authorization, there are often more fields in the form than are actually stored. An example would be a checkbox "I agree to the terms of use" which is checked by the controller and then discarded if checked, validation error otherwise. If cancancan ignores this attribute (since it's not DB backed), a form whitelisting attributes by using cancancan's `permitted_attributes` would miss on this field.

This becomes particularly important when using cancancan together with Gems like `active_type`.