### PR TITLE
Fix: rule_spec should honor DB setting

### DIFF
--- a/spec/cancan/rule_spec.rb
+++ b/spec/cancan/rule_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe CanCan::Rule do
       end
 
       before do
-        ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+        connect_db
         ActiveRecord::Migration.verbose = false
         ActiveRecord::Schema.define do
           create_table(:watermelons) do |t|


### PR DESCRIPTION
I noticed when running db-specific tests e.g.
```
DB='postgres' bundle exec appraisal activerecord_6.1.0 rake
```
that `spec/cancan/rule_spec.rb` could fail if sqlite not available, because it was ignoring the DB context and always/only running with sqlite. 

This is just a quick fix to ensure that `spec/cancan/rule_spec.rb` runs like all other tests with the specific DB selected.