### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/cancancan

### DIFF
--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -10,7 +10,8 @@ Gem::Specification.new do |s|
   s.authors     = ['Alessandro Rodi (Renuo AG)', 'Bryan Rite', 'Ryan Bates', 'Richard Wilson']
   s.email       = 'alessandro.rodi@renuo.ch'
   s.homepage    = 'https://github.com/CanCanCommunity/cancancan'
-  s.metadata = { 'funding_uri' => 'https://github.com/sponsors/coorasse' }
+  s.metadata = { 'changelog_uri' => 'https://github.com/CanCanCommunity/cancancan/blob/develop/CHANGELOG.md',
+                 'funding_uri' => 'https://github.com/sponsors/coorasse' }
   s.summary     = 'Simple authorization solution for Rails.'
   s.description = 'Simple authorization solution for Rails. All permissions are stored in a single location.'
   s.platform    = Gem::Platform::RUBY


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/cancancan which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/