### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/cancancan.gemspec
+++ b/cancancan.gemspec
@@ -10,7 +10,10 @@ Gem::Specification.new do |s|
   s.authors     = ['Alessandro Rodi (Renuo AG)', 'Bryan Rite', 'Ryan Bates', 'Richard Wilson']
   s.email       = 'alessandro.rodi@renuo.ch'
   s.homepage    = 'https://github.com/CanCanCommunity/cancancan'
-  s.metadata = { 'funding_uri' => 'https://github.com/sponsors/coorasse' }
+  s.metadata = { 
+    'funding_uri' => 'https://github.com/sponsors/coorasse',
+    'changelog_uri' => 'https://github.com/CanCanCommunity/cancancan/blob/develop/CHANGELOG.md'
+  }
   s.summary     = 'Simple authorization solution for Rails.'
   s.description = 'Simple authorization solution for Rails. All permissions are stored in a single location.'
   s.platform    = Gem::Platform::RUBY


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata Useful for running https://github.com/MaximeD/gem_updater