### PR TITLE
fix(STI): compress rules per subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [#849](https://github.com/CanCanCommunity/cancancan/pull/849): Update tests matrix. ([@coorasse][])
 * [#843](https://github.com/CanCanCommunity/cancancan/pull/843): Compress duplicate rules. ([@MrChoclate][])
 * [#841](https://github.com/CanCanCommunity/cancancan/pull/841): New https://cancancan.dev website. ([@pandermatt][])
-* [#839](https://github.com/CanCanCommunity/cancancan/pull/839): switch from database column detection to Rails attributes detection. ([@kalsan][])
+* [#839](https://github.com/CanCanCommunity/cancancan/pull/839): Switch from database column detection to Rails attributes detection. ([@kalsan][])
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+## 3.6.2
+
+* [#855](https://github.com/CanCanCommunity/cancancan/pull/855): Fix issue with compressing STI rules. ([@sjoulbak][])
+
 ## 3.6.0
 
 * [#849](https://github.com/CanCanCommunity/cancancan/pull/849): Update tests matrix. ([@coorasse][])
 * [#843](https://github.com/CanCanCommunity/cancancan/pull/843): Compress duplicate rules. ([@MrChoclate][])
 * [#841](https://github.com/CanCanCommunity/cancancan/pull/841): New https://cancancan.dev website. ([@pandermatt][])
 * [#839](https://github.com/CanCanCommunity/cancancan/pull/839): switch from database column detection to Rails attributes detection. ([@kalsan][])
+
 ## 3.5.0
 
 * [#653](https://github.com/CanCanCommunity/cancancan/pull/653): Add support for using an nil relation as a condition. ([@ghiculescu][])
@@ -716,3 +721,4 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@MrChoclate]: https://github.com/MrChoclate
 [@pandermatt]: https://github.com/pandermatt
 [@kalsan]: https://github.com/kalsan
+[@sjoulbak]: https://github.com/sjoulbak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * [#855](https://github.com/CanCanCommunity/cancancan/pull/855): Fix issue with compressing STI rules. ([@sjoulbak][])
 
+## 3.6.1
+
+* [#847](https://github.com/CanCanCommunity/cancancan/pull/847): Fix: rule_spec should honor DB setting ([@tardate][])
+
 ## 3.6.0
 
 * [#849](https://github.com/CanCanCommunity/cancancan/pull/849): Update tests matrix. ([@coorasse][])
@@ -721,4 +725,5 @@ Please read the [guide on migrating from CanCanCan 2.x to 3.0](https://github.co
 [@MrChoclate]: https://github.com/MrChoclate
 [@pandermatt]: https://github.com/pandermatt
 [@kalsan]: https://github.com/kalsan
+[@tardate]: https://github.com/tardate
 [@sjoulbak]: https://github.com/sjoulbak

--- a/lib/cancan/rules_compressor.rb
+++ b/lib/cancan/rules_compressor.rb
@@ -31,9 +31,9 @@ module CanCan
     def simplify(rules)
       seen = Set.new
       rules.reverse_each.filter_map do |rule|
-        next if seen.include?(rule.conditions)
+        next if seen.include?(rule.subjects => rule.conditions)
 
-        seen.add(rule.conditions)
+        seen.add(rule.subjects => rule.conditions)
         rule
       end.reverse
     end

--- a/lib/cancan/version.rb
+++ b/lib/cancan/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CanCan
-  VERSION = '3.5.0'.freeze
+  VERSION = '3.6.2'.freeze
 end

--- a/spec/cancan/rule_compressor_spec.rb
+++ b/spec/cancan/rule_compressor_spec.rb
@@ -137,6 +137,32 @@ describe CanCan::RulesCompressor do
     end
   end
 
+  context 'when STI is in use' do
+    before do
+      class Pet
+      end
+
+      class Cat < Pet
+      end
+
+      class Dog < Pet
+      end
+    end
+
+    let(:rules) do
+      [
+        can(:read, Pet, capacity: 5),
+        can(:read, Cat, capacity: 5),
+        can(:read, Dog, capacity: 6),
+        can(:read, Pet, capacity: 5)
+      ]
+    end
+
+    it 'minimizes the rules, by removing useless previous rules' do
+      expect(described_class.new(rules).rules_collapsed).to eq [rules[1], rules[2], rules[3]]
+    end
+  end
+
   # TODO: not supported yet
   xcontext 'merges rules' do
     let(:rules) do


### PR DESCRIPTION
Hi 👋 

This is a follow-up PR for the changes of: https://github.com/CanCanCommunity/cancancan/pull/843

I updated cancancan to its latest version earlier today and noticed that some of our authorization specs were failing. It was related with the latest changes of compressing duplicate rules in combination with STI subjects. I provided a spec to reproduce the issue and a solution as well, which will modify `seen` in `lib/cancan/rules_compressor.rb` to keep track of seen rules per given subjects. This solution works for our app.

As a chore I uppercased a changelog entry body to fix a spec. 

I added a missing changelog entry for 3.6.1. Please note that 3.6.1 is already released at Rubygems, but there is no tag at this repo.

Let me know if I need to do anything else to get this PR merged 🙏