### PR TITLE
"Cannot" with association hash conditions : accessible_by generates incorrect SQL (Postgres / ActiveRecord)

### DIFF
--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -198,11 +198,11 @@ module CanCan
         conditions = sanitize_sql(conditions_hash)
         case sql
         when true_sql
-          behavior ? true_sql : "not (#{conditions})"
+          behavior ? true_sql : "(not (#{conditions}) OR (#{conditions}) IS NULL)"
         when false_sql
           behavior ? conditions : false_sql
         else
-          behavior ? "(#{conditions}) OR (#{sql})" : "not (#{conditions}) AND (#{sql})"
+          behavior ? "(#{conditions}) OR (#{sql})" : "(not (#{conditions}) OR (#{conditions}) IS NULL) AND (#{sql})"
         end
       end
 


### PR DESCRIPTION
I hope it's enough to link to the relevant issue #214 

The commit addresses the issue at its root by checking for _IS NULL_. PostgreSQL can't compare null values with any other value. 