### PR TITLE
Check rule's subject's inheritance if subject is a Class or Module

### DIFF
--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -7,6 +7,7 @@ module CanCan
       return call_block_with_all(action, subject, extra_args) if @match_all
       return matches_block_conditions(subject, attribute, *extra_args) if @block
       return matches_non_block_conditions(subject) unless conditions_empty?
+      return subject_descendant?(subject) if subject_class?(subject)
 
       true
     end
@@ -142,6 +143,13 @@ module CanCan
       # which it's `==` implementation will fetch all records for comparison
 
       (@conditions.is_a?(Hash) && @conditions == {}) || @conditions.nil?
+    end
+
+    def subject_descendant?(subject)
+      return true if @subjects.include?(:all)
+
+      subject = subject.values.first if subject.is_a?(Hash)
+      @subjects.any? { |sub| sub.is_a?(Module) && sub >= subject }
     end
   end
 end

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -1426,6 +1426,27 @@ RSpec.describe CanCan::ModelAdapters::ActiveRecordAdapter do
       end
     end
 
+    it 'cannot rules are not effecting parent class' do
+      u1 = User.create!(name: 'pippo')
+      ability = Ability.new(u1)
+
+      ability.can :manage, Vehicle
+      ability.cannot :manage, Car
+
+      expect(ability.can?(:index, Vehicle)).to eq(true)
+      expect(ability.can?(:index, Car)).to eq(false)
+    end
+
+    it 'can rules are not effecting parent class' do
+      u1 = User.create!(name: 'pippo')
+      ability = Ability.new(u1)
+
+      ability.can :manage, Car
+
+      expect(ability.can?(:index, Vehicle)).to eq(false)
+      expect(ability.can?(:index, Car)).to eq(true)
+    end
+
     it 'recognises rules applied to the base class' do
       u1 = User.create!(name: 'pippo')
 


### PR DESCRIPTION
This change fixes the following problem of STI classes

```ruby
# given "class Child < Parent"
can :read, Parent
cannot :read, Child

can? :read, Parent # => false, but should be true
```
The reason is that `relevant_rules` will fetch both ancestors and subclasses rules when ActiveRecord is used, where non-sti classes don't have this problem.

The fix is simple: just check if the rule's subject is a ancestor or itself