### PR TITLE
Fix: `permitted_attributes` ignores `cannot` and default-deny rules

### DIFF
--- a/lib/cancan/ability/strong_parameter_support.rb
+++ b/lib/cancan/ability/strong_parameter_support.rb
@@ -10,6 +10,8 @@ module CanCan
       # they are added. The 'reverse' is so that attributes will be added before the
       # 'cannot' rules remove them.
       def permitted_attributes(action, subject)
+        return [] unless can?(action, subject)
+
         relevant_rules(action, subject)
           .reverse
           .select { |rule| rule.matches_conditions? action, subject }

--- a/spec/cancan/ability_spec.rb
+++ b/spec/cancan/ability_spec.rb
@@ -665,6 +665,16 @@ describe CanCan::Ability do
     expect(@ability.can?(:update, Range, :name)).to be(true)
   end
 
+  it 'returns an empty array for permitted_attributes when no ability is defined' do
+    expect(@ability.permitted_attributes(:update, NamedUser)).to eq([])
+  end
+
+  it 'returns an empty array for permitted_attributes if the action is explicitly forbidden' do
+    @ability.can :update, NamedUser
+    @ability.cannot :update, NamedUser # explicitly deny
+    expect(@ability.permitted_attributes(:update, NamedUser)).to eq([])
+  end
+
   it 'returns an array of permitted attributes for a given action and subject' do
     @ability.can :read, NamedUser
     @ability.can :read, Array, :special


### PR DESCRIPTION
This PR fixes a bug in `permitted_attributes` where it would return a list of attributes for an action, even when that action was explicitly forbidden by a `cannot` rule or denied by default. The expected behavior in a "default-deny" system is for it to return an empty array.

For example, given the ability:

```ruby
cannot :update, Project
```

The call `ability.permitted_attributes(:update, Project)` would incorrectly return all model attributes, instead of the expected `[]`. This also occurred in default-deny scenarios where no ability was defined at all for a given action.

### The Fix

The fix is to add a guard clause at the beginning of the `permitted_attributes` method. It now uses the core `can?` method to check if the user is authorized to perform the action *before* collecting the attributes. If `can?` returns `false`, `permitted_attributes` will now correctly return an empty array.

This ensures that the behavior of `permitted_attributes` is consistent with the rest of the library's authorization logic.

I considered an alternative which changes the logic of the method completely.
The idea was to collect all forbidden attributes and subtract then the allowed. 
And then to return all attributes minus the forbidden attributes.