### PR TITLE
Optimize can?

### DIFF
--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -306,9 +306,9 @@ module CanCan
     def alternative_subjects(subject)
       subject = subject.class unless subject.is_a?(Module)
       if subject.respond_to?(:subclasses) && defined?(ActiveRecord::Base) && subject < ActiveRecord::Base
-        [:all, *(subject.ancestors + subject.subclasses), subject.class.to_s]
+        [:all, *(subject.ancestors + subject.subclasses), subject.class.name]
       else
-        [:all, *subject.ancestors, subject.class.to_s]
+        [:all, *subject.ancestors, subject.class.name]
       end
     end
   end

--- a/lib/cancan/ability.rb
+++ b/lib/cancan/ability.rb
@@ -72,12 +72,15 @@ module CanCan
     #
     # Also see the RSpec Matchers to aid in testing.
     def can?(action, subject, attribute = nil, *extra_args)
-      match = extract_subjects(subject).lazy.map do |a_subject|
-        relevant_rules_for_match(action, a_subject).detect do |rule|
-          rule.matches_conditions?(action, a_subject, attribute, *extra_args) && rule.matches_attributes?(attribute)
+      extract_subjects(subject).each do |a_subject|
+        relevant_rules_for_match(action, a_subject).each do |rule|
+          next if !rule.matches_conditions?(action, a_subject, attribute, *extra_args) || !rule.matches_attributes?(attribute)
+
+          return rule.base_behavior
         end
-      end.reject(&:nil?).first
-      match ? match.base_behavior : false
+      end
+
+      false
     end
 
     # Convenience method which works the same as "can?" but returns the opposite value.

--- a/lib/cancan/ability/rules.rb
+++ b/lib/cancan/ability/rules.rb
@@ -36,7 +36,7 @@ module CanCan
         return [] unless @rules
 
         relevant = possible_relevant_rules(subject).select do |rule|
-          rule.expanded_actions = expand_actions(rule.actions)
+          rule.expanded_actions ||= expand_actions(rule.actions)
           rule.relevant? action, subject
         end
         relevant.reverse!.uniq!

--- a/lib/cancan/ability/rules.rb
+++ b/lib/cancan/ability/rules.rb
@@ -52,7 +52,7 @@ module CanCan
           positions.compact!
           positions.flatten!
           positions.sort!
-          positions.map { |i| @rules[i] }
+          @rules.values_at(*positions)
         end
       end
 

--- a/lib/cancan/class_matcher.rb
+++ b/lib/cancan/class_matcher.rb
@@ -24,7 +24,7 @@ class SubjectClassMatcher
 
   def self.matches_class_or_is_related(subject, sub)
     sub.is_a?(Module) && (subject.is_a?(sub) ||
-        subject.class.to_s == sub.to_s ||
+        subject.class.name == sub.to_s ||
         (subject.is_a?(Module) && subject.ancestors.include?(sub)))
   end
 end

--- a/lib/cancan/relevant.rb
+++ b/lib/cancan/relevant.rb
@@ -21,7 +21,7 @@ module CanCan
     def matches_subject_class?(subject)
       @subjects.any? do |sub|
         sub.is_a?(Module) && (subject.is_a?(sub) ||
-            subject.class.to_s == sub.to_s ||
+            subject.class.name == sub.to_s ||
             (subject.is_a?(Module) && subject.ancestors.include?(sub)))
       end
     end

--- a/lib/cancan/rule.rb
+++ b/lib/cancan/rule.rb
@@ -13,7 +13,8 @@ module CanCan
     include Relevant
     include ParameterValidators
     attr_reader :base_behavior, :subjects, :actions, :conditions, :attributes, :block
-    attr_writer :expanded_actions, :conditions
+    attr_writer :conditions
+    attr_accessor :expanded_actions
 
     # The first argument when initializing is the base_behavior which is a true/false
     # value. True for "can" and false for "cannot". The next two arguments are the action
@@ -33,6 +34,7 @@ module CanCan
       @attributes = wrap(attributes)
       @conditions = extra_args || {}
       @block = block
+      @expanded_actions = nil
     end
 
     def inspect


### PR DESCRIPTION
Hi, we are using CanCanCan in rails project with 200+ ability rules and there are many pages that do many `can?` checks when being rendered. We noticed that the `can?` checks take up significant part of our response time.

Here is attempt to speed things up. From our testing, the most significant change would be to cache and shorten `subject.ancestors` in `alternative_subjects` but that would be bigger change and might break some edge case usage of this gem so it is not included.

As you can see below, speedup varies between 20-70%. Every commit includes different optimization and can be reverted if the change is not ok.

Simple benchmark (which just creates small and big ability class with some classes and checks). It attempts to simulate different types of abilities and workflow but is very basic and definitely could be improved:
```ruby
require "cancancan"
require "benchmark/ips"
require "active_record"

$classes = 50.times.map { Class.new } + 50.times.map { Class.new(ActiveRecord::Base) }
$classes.flat_map { Class.new(_1) }
$first_last_classes = [$classes.first, $classes.last]
class BigAbility
  include CanCan::Ability

  def initialize
    alias_action :index, :show, :search, to: :read
    $classes.shuffle(random: Random.new(1)).each do |klass|
      can [:index, :create], klass
    end
    100.times do |i|
      can :read, :"custom#{i}"
    end
    $classes.shuffle(random: Random.new(1)).each do |klass|
      can [:delete], klass
    end
  end
end

class SmallAbility
  include CanCan::Ability

  def initialize
    $first_last_classes.each do |klass|
      can :read, klass
    end
  end
end

Benchmark.ips do |x|
  x.report("single_check_big") { ability = BigAbility.new; $classes.each { |klass| ability.can?(:read, klass) } }
  x.report("multi_checks_big") { ability = BigAbility.new; $first_last_classes.each { |klass| 10.times { ability.can?(:read, klass) } } }
  x.report("single_check_small") { ability = SmallAbility.new; $classes.each { |klass| ability.can?(:read, klass) } }
  x.report("multi_checks_small") { ability = SmallAbility.new; $first_last_classes.each { |klass| 10.times { ability.can?(:read, klass) } } }
end; 0
```

Results:
CanCanCan 3.6.0:
```
ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
Warming up --------------------------------------
    single_check_big    41.000 i/100ms
    multi_checks_big   104.000 i/100ms
  single_check_small    90.000 i/100ms
  multi_checks_small   297.000 i/100ms
Calculating -------------------------------------
    single_check_big    422.154 (± 6.4%) i/s    (2.37 ms/i) -      2.132k in   5.079771s
    multi_checks_big      1.036k (± 1.0%) i/s  (965.03 μs/i) -      5.200k in   5.018654s
  single_check_small    901.486 (± 2.1%) i/s    (1.11 ms/i) -      4.590k in   5.093925s
  multi_checks_small      2.942k (± 0.9%) i/s  (339.87 μs/i) -     14.850k in   5.047496s
```
These changes:
```
ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
Warming up --------------------------------------
    single_check_big    58.000 i/100ms
    multi_checks_big   123.000 i/100ms
  single_check_small   157.000 i/100ms
  multi_checks_small   482.000 i/100ms
Calculating -------------------------------------
    single_check_big    575.897 (± 4.7%) i/s    (1.74 ms/i) -      2.900k in   5.049236s
    multi_checks_big      1.227k (± 2.0%) i/s  (814.67 μs/i) -      6.150k in   5.012142s
  single_check_small      1.570k (± 1.0%) i/s  (636.81 μs/i) -      8.007k in   5.099492s
  multi_checks_small      4.855k (± 1.0%) i/s  (205.96 μs/i) -     24.582k in   5.063452s
```