### PR TITLE
Fix can? for ActiveRecord relation-based conditions

### DIFF
--- a/lib/cancan/conditions_matcher.rb
+++ b/lib/cancan/conditions_matcher.rb
@@ -88,6 +88,9 @@ module CanCan
     end
 
     def condition_match?(attribute, value)
+      if defined?(ActiveRecord) && value.is_a?(ActiveRecord::Relation)
+        value = value.map { |v| v.attributes.compact_blank.values[0] }
+      end
       case value
       when Hash
         hash_condition_match?(attribute, value)

--- a/spec/cancan/model_adapters/active_record_adapter_spec.rb
+++ b/spec/cancan/model_adapters/active_record_adapter_spec.rb
@@ -276,6 +276,32 @@ RSpec.describe CanCan::ModelAdapters::ActiveRecordAdapter do
         expect(Article.accessible_by(@ability)).to match_array([article1])
       end
 
+      it 'matches records for can? when a condition value is an ActiveRecord relation selecting ids' do
+        user = User.create!(name: 'Arthur Dent')
+        article = Article.create!(name: 'How to fly', user: user)
+        other_article = Article.create!(name: 'Mostly Harmless')
+        ability = Ability.new(user)
+
+        ability.can :read, Article, id: Article.where(user_id: user.id).select(:id)
+
+        expect(Article.accessible_by(ability)).to match_array([article])
+        expect(ability.can?(:read, article)).to eq(true)
+        expect(ability.can?(:read, other_article)).to eq(false)
+      end
+
+      it 'matches records for can? when a condition value is an ActiveRecord relation selecting names' do
+        user = User.create!(name: 'Arthur Dent')
+        article = Article.create!(name: 'How to fly', user: user)
+        other_article = Article.create!(name: 'Mostly Harmless')
+        ability = Ability.new(user)
+
+        ability.can :read, Article, name: Article.where(user_id: user.id).select(:name)
+
+        expect(Article.accessible_by(ability)).to match_array([article])
+        expect(ability.can?(:read, article)).to eq(true)
+        expect(ability.can?(:read, other_article)).to eq(false)
+      end
+
       it 'fetches only associated records when using with a scope for conditions' do
         @ability.can :read, Article, Article.where(secret: true)
         category1 = Category.create!(visible: false)


### PR DESCRIPTION
This PR fixes an inconsistency between `accessible_by` and `can?` when an ability condition uses an `ActiveRecord::Relation` as the condition value.

Example:

```ruby
can :read, Article, id: Article.where(user_id: user.id).select(:id)
```

Before this change:

* `Article.accessible_by(ability)` correctly returns the expected records
* `ability.can?(:read, article)` incorrectly returns `false`

After this change:

* `accessible_by` continues to behave correctly
* `can?` now returns the expected result for matching records

---

### Problem

`accessible_by` works because ActiveRecord conditions are translated into SQL.

However, `can?` performs an in-memory condition match, and when the condition value is an `ActiveRecord::Relation`, it was comparing the record attribute against relation objects rather than against the selected scalar values.

This caused behavior like:

```ruby
user = User.create!(name: 'Arthur Dent')
article = Article.create!(name: 'How to fly', user:)

ability = Ability.new(user)
ability.can :read, Article, id: Article.where(user_id: user.id).select(:id)

Article.accessible_by(ability) # => includes article
ability.can?(:read, article)   # => false (before)
ability.can?(:read, article)   # => true  (after)
```

---

### Change

This PR updates `CanCan::ConditionsMatcher#condition_match?` so that when a condition value is an `ActiveRecord::Relation`, it is normalized into the selected record values before performing the in-memory match.

This makes `can?` consistent with `accessible_by` for relation-backed conditions such as:

```ruby
id: Article.where(user_id: user.id).select(:id)
```

---

### Test coverage

Added a spec in:

```ruby
spec/cancan/model_adapters/active_record_adapter_spec.rb
```

The example verifies that:

* `accessible_by` returns the expected matching record
* `can?` returns `true` for the matching record
* `can?` returns `false` for a non-matching record

---

### Why this matters

Using subqueries / relation-backed conditions is already a valid and useful pattern in ability definitions, especially when trying to avoid eager-loading IDs into Ruby arrays.

This change ensures that:

* SQL-backed authorization (`accessible_by`)
* in-memory authorization (`can?`)

follow the same logic and produce consistent results.

---

### Notes for reviewers

This change is intentionally narrow and only affects in-memory condition matching when a condition value is an `ActiveRecord::Relation`.

It does not change SQL generation or `accessible_by` behavior, which was already correct.