### PR TITLE
fix: prevent accessible_by from permanently overwriting shared rule conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [#876](https://github.com/CanCanCommunity/cancancan/issues/876): Fix `accessible_by` permanently overwriting shared rule conditions, causing `can?` to fail for models sharing the same rule. ([@say-apm35][])
+
 ## 3.6.0
 
 * [#849](https://github.com/CanCanCommunity/cancancan/pull/849): Update tests matrix. ([@coorasse][])

--- a/lib/cancan/model_adapters/active_record_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_adapter.rb
@@ -18,11 +18,18 @@ module CanCan
 
       def initialize(model_class, rules)
         super
-        @compressed_rules = if CanCan.rules_compressor_enabled
-                              RulesCompressor.new(@rules.reverse).rules_collapsed.reverse
-                            else
-                              @rules
-                            end
+        base_rules = if CanCan.rules_compressor_enabled
+                       RulesCompressor.new(@rules.reverse).rules_collapsed.reverse
+                     else
+                       @rules
+                     end
+        # Dup each rule so that normalization for this model class does not permanently
+        # alter the shared rule objects. ConditionsNormalizer replaces rule.conditions with
+        # a newly computed hash, which overwrites the shared rule's conditions and corrupts
+        # subsequent can? checks for other models sharing the same rule. Duping the rule
+        # gives each adapter its own Rule shell so the conditions= assignment is local.
+        # See GitHub issue #876.
+        @compressed_rules = base_rules.map(&:dup)
         StiNormalizer.normalize(@compressed_rules)
         ConditionsNormalizer.normalize(model_class, @compressed_rules)
       end

--- a/spec/cancan/model_adapters/conditions_normalizer_spec.rb
+++ b/spec/cancan/model_adapters/conditions_normalizer_spec.rb
@@ -5,36 +5,38 @@ RSpec.describe CanCan::ModelAdapters::ConditionsNormalizer do
     connect_db
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Schema.define do
-      create_table(:articles) do |t|
+      create_table(:articles, force: true) do |t|
       end
 
-      create_table(:users) do |t|
+      create_table(:users, force: true) do |t|
         t.string :name
       end
 
-      create_table(:comments) do |t|
+      create_table(:comments, force: true) do |t|
       end
 
-      create_table(:spread_comments) do |t|
+      create_table(:spread_comments, force: true) do |t|
         t.integer :article_id
         t.integer :comment_id
       end
 
-      create_table(:legacy_mentions) do |t|
+      create_table(:legacy_mentions, force: true) do |t|
         t.integer :user_id
         t.integer :article_id
       end
 
-      create_table(:attachments) do |t|
+      create_table(:attachments, force: true) do |t|
         t.references :record, polymorphic: true
         t.integer :blob_id
       end
 
-      create_table(:blob) do |t|
+      create_table(:blob, force: true) do |t|
       end
     end
 
     class Article < ActiveRecord::Base
+      self.record_timestamps = false
+
       has_many :spread_comments
       has_many :comments, through: :spread_comments
       has_many :mentions
@@ -43,11 +45,15 @@ RSpec.describe CanCan::ModelAdapters::ConditionsNormalizer do
     end
 
     class Comment < ActiveRecord::Base
+      self.record_timestamps = false
+
       has_many :spread_comments
       has_many :articles, through: :spread_comments
     end
 
     class SpreadComment < ActiveRecord::Base
+      self.record_timestamps = false
+
       belongs_to :comment
       belongs_to :article
     end
@@ -104,5 +110,33 @@ RSpec.describe CanCan::ModelAdapters::ConditionsNormalizer do
     rule = CanCan::Rule.new(true, :read, Supplier, account_history: { name: 'pippo' })
     CanCan::ModelAdapters::ConditionsNormalizer.normalize(Supplier, [rule])
     expect(rule.conditions).to eq(accountant: { account_history: { name: 'pippo' } })
+  end
+
+  context 'with accessible_by using has_many-through conditions' do
+    let(:ability) { double.extend(CanCan::Ability) }
+
+    before do
+      @article1 = Article.create!
+      @comment1 = Comment.create!
+      SpreadComment.create!(article: @article1, comment: @comment1)
+    end
+
+    it 'does not overwrite shared rule conditions after accessible_by is called' do
+      # Regression test for issue #876.
+      # accessible_by triggers ConditionsNormalizer which expands has_many-through conditions
+      # and writes the result back to rule.conditions on the shared Rule object.
+      # Without the adapter fix, the shared Rule's conditions are permanently replaced,
+      # breaking future can? checks that rely on the original un-normalized conditions.
+      ability.can :read, Comment, articles: { id: @article1.id }
+      rule = ability.send(:rules).last
+      conditions_before_accessible_by = rule.conditions
+
+      Comment.accessible_by(ability)
+
+      # The shared Rule object must not have its conditions replaced.
+      # Without the fix: rule.conditions becomes { spread_comments: { article: { id: ... } } }.
+      # With the fix: rule.conditions is still the original hash object.
+      expect(rule.conditions).to be(conditions_before_accessible_by)
+    end
   end
 end


### PR DESCRIPTION
## What does this fix?

Calling `accessible_by` for one model class permanently overwrites `rule.conditions` on the **shared** `Rule` objects stored in the ability's `@rules`. A subsequent `can?` check for a different model that shares the same rule then uses the already-normalized conditions, which may reference associations that do not exist on that model, causing `NoMethodError` or wrong results.

### Reproduction (from #876)

```ruby
# Ability definition - rule applies to both Project and Activity
can :read, [Project, Activity], client: { id: current_client.id }

# Project belongs_to :client (direct)
# Activity has_many-through path to client via :project

# Step 1 - works fine before accessible_by is called
can?(:read, @project)  # => correct result

# Step 2 - triggers ConditionsNormalizer for Activity
# Rewrites rule.conditions from { client: { id: x } }
# to { project: { client: { id: x } } } on the SHARED Rule object
Activity.accessible_by(current_ability)

# Step 3 - now broken
can?(:read, @project)  # => NoMethodError: undefined method `project' for Project
```

## Fix

`ActiveRecordAdapter#initialize` now maps `@compressed_rules` through `Rule#dup` before passing to `StiNormalizer` and `ConditionsNormalizer`. The dup gives each adapter its own copy of the rule shell, so `conditions=` assignments from the normalizers are local and never touch the originals in `@rules`.

```ruby
@compressed_rules = base_rules.map(&:dup)
```

## Tests

Added a regression spec to `conditions_normalizer_spec.rb`:

- Confirms `rule.conditions` is **unchanged** after `accessible_by` is called (object identity preserved)
- Fails without the fix (rule.conditions becomes the normalized form)
- Passes with the fix

All 305 examples pass (0 failures, 2 pending) across both defined and random order.

Closes #876