### PR TITLE
Use lease_connection on Rails 7.2+ in ActiveRecord5Adapter

### DIFF
--- a/lib/cancan/model_adapters/active_record_5_adapter.rb
+++ b/lib/cancan/model_adapters/active_record_5_adapter.rb
@@ -49,11 +49,22 @@ module CanCan
       def visit_nodes(node)
         # Rails 5.2 adds a BindParam node that prevents the visitor method from properly compiling the SQL query
         if self.class.version_greater_or_equal?('5.2.0')
-          connection = @model_class.send(:connection)
+          connection = model_connection
           collector = Arel::Collectors::SubstituteBinds.new(connection, Arel::Collectors::SQLString.new)
           connection.visitor.accept(node, collector).value
         else
-          @model_class.send(:connection).visitor.compile(node)
+          model_connection.visitor.compile(node)
+        end
+      end
+
+      # Rails 7.2 soft-deprecated ActiveRecord::Base.connection in favour of
+      # lease_connection, which better describes its lifecycle. Fall back to
+      # connection for Rails < 7.2 where lease_connection is not defined.
+      def model_connection
+        if @model_class.respond_to?(:lease_connection)
+          @model_class.lease_connection
+        else
+          @model_class.send(:connection)
         end
       end
     end


### PR DESCRIPTION
Closes #893.

### Why

Rails 7.2 soft-deprecated `ActiveRecord::Base.connection` in favour of `lease_connection`, which better reflects that the caller is acquiring a connection from the pool rather than holding a permanent one (see [rails/rails#51230](https://github.com/rails/rails/pull/51230)). `connection` still works on 7.2+, but apps that opt into stricter connection-pool semantics (`ActiveRecord.permanent_connection_checkout = :deprecated` or `:disallowed`) see warnings or errors from `ActiveRecord5Adapter#visit_nodes`.

### What

Prefer `@model_class.lease_connection` when defined; fall back to `@model_class.connection` on Rails < 7.2. The conditional uses `respond_to?(:lease_connection)` rather than a Rails-version check so the same code path works against ActiveRecord main without further changes. This is the pattern used by other gems spanning the 7.2 boundary, e.g. [`good_job`](https://github.com/bensheldon/good_job/blob/main/app/models/good_job/base_record.rb) and [`pg_ha_migrations`](https://github.com/braintree/pg_ha_migrations).

### Backward compatibility

No behavioural change on Rails 5.2 / 6.x / 7.0 / 7.1 — `lease_connection` is undefined there and the fallback path keeps calling `connection`. The existing CI matrix should cover the fallback.